### PR TITLE
bug 7669 Fix Doodle Labs radio support: signal bar, settings UI, and disconnect guard

### DIFF
--- a/custom/src/ARLink/ARLinkIndicator.qml
+++ b/custom/src/ARLink/ARLinkIndicator.qml
@@ -25,6 +25,7 @@ Item {
     property var  _skyRssiA:    arManager.skyRssiA
     property var  _skyRssiB:    arManager.skyRssiB
     property var  _activeVehicle: QGroundControl.multiVehicleManager.activeVehicle
+    property bool _isDoodle: arManager.version == "DoodleLabs ubus"
 
     Component {
         id:                                     arRssiInfo
@@ -75,7 +76,7 @@ Item {
                     }
 
                     QGCLabel {
-                        text:                   qsTr("Sky RSSI:")
+                        text:                   _isDoodle ? qsTr("Peer RSSI:") : qsTr("Sky RSSI:")
                         color:                  qgcPal.text
                     }
                     QGCLabel {
@@ -97,6 +98,7 @@ Item {
 
                 QGCButton {
                     text:                       qsTr("Start Pair")
+                    visible:                    !_isDoodle
                     width:                      ScreenTools.defaultFontPixelWidth * 15
                     anchors.horizontalCenter:   parent.horizontalCenter
                     onClicked: {
@@ -108,14 +110,23 @@ Item {
         }
     }
 
-    function getSignalStrength(rssi) {
-        if(rssi < 10) return 0;
-        if(rssi >= 108) return 30;
-        else if(rssi >= 103) return 50;
-        else if(rssi >= 98) return 70;
-        else if(rssi >= 91) return 85;
-        else return 100;
+function getSignalStrength(rssi) {
+    if (_isDoodle) {
+    if(rssi > 95) return 0;        // Link lost - 0 bars
+    else if(rssi > 85) return 30;  // Poor - 1 bar
+    else if(rssi > 78) return 40;  // Weak - 2 bars
+    else if(rssi > 70) return 60;  // Fair - 3 bars
+    else if(rssi > 50) return 85;  // Good - 4 bars
+    else return 100;               // Excellent (≤50) + Too Strong (<30) - 5 bars
     }
+    // Enpulse: original thresholds        if(rssi < 10) return 0;
+    if(rssi < 10) return 0;
+    if(rssi >= 108) return 30;
+    else if(rssi >= 103) return 50;
+    else if(rssi >= 98) return 70;
+    else if(rssi >= 91) return 85;
+    else return 100;
+}
 
     // Signal
     Row {
@@ -135,12 +146,12 @@ Item {
             spacing: 0
             QGCLabel {
                 id:                     frequencyLable
-                text:                   arManager.is24G ? "2.4G" : "5.8G"
+                text:                   _isDoodle ? "2.4G" : (arManager.is24G ? "2.4G" : "5.8G")
                 font.pointSize:         ScreenTools.defaultFontPointSize
             }
             QGCLabel {
                 id:                     linkNameLable
-                text:                   "Enpulse"
+                text:                   _isDoodle ? "DoodleLab" : "Enpulse"
                 font.pointSize:         ScreenTools.defaultFontPointSize
             }
         }
@@ -284,7 +295,7 @@ Item {
         onClicked: {
             if (_connected) {
                 mainWindow.showIndicatorPopup(_root, arRssiInfo)
-            } else {                
+            } else if (!_isDoodle) {                
                 mainWindow.hideIndicatorPopup()
                 mainWindow.showCustomMessageDialog(arPairGuideComponent)
             }

--- a/custom/src/ARLink/ARManager.cpp
+++ b/custom/src/ARLink/ARManager.cpp
@@ -1,5 +1,7 @@
 ﻿#include "ARManager.h"
 #include "JsonHelper.h"
+#include "CustomPlugin.h"
+#include "CustomSettings.h"
 #include <QQmlEngine>
 #include <QJsonDocument>
 #include <QNetworkInterface>
@@ -199,6 +201,19 @@ void ARManager::setToolbox(QGCToolbox* toolbox)
     QGCTool::setToolbox(toolbox);
     QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
     qmlRegisterUncreatableType<ARManager>("CustomQmlInterface", 1, 0, "ARManager", "Reference only");
+
+    // Read Doodle Labs IP from persistent settings
+    CustomPlugin* plugin = dynamic_cast<CustomPlugin*>(_toolbox->corePlugin());
+    if (plugin && plugin->settings()) {
+        Fact* ipFact = plugin->settings()->doodleLabsIP();
+        _doodleDeviceIP = ipFact->rawValue().toString();
+        connect(ipFact, &Fact::rawValueChanged, this, [this](QVariant value) {
+            _doodleDeviceIP = value.toString();
+            _rpcSession.clear();
+            qInfo() << "[Doodle Labs] IP changed to:" << _doodleDeviceIP;
+        });
+    }
+
 #if !defined (Q_OS_ANDROID)
     if(_auto)
 #endif

--- a/custom/src/ARLink/ARManager.cpp
+++ b/custom/src/ARLink/ARManager.cpp
@@ -4,6 +4,90 @@
 #include <QJsonDocument>
 #include <QNetworkInterface>
 #include <QHostAddress>
+#include <QJsonArray>              // json array
+#include <QNetworkRequest>         // http request
+#include <QSslConfiguration>       // ssl protocol
+#include <QSslSocket>              // secure network
+
+namespace {
+
+    // Robust JSON value-to-int parser. Handles doubles, strings (with units like "54000 kbit/s"), and nested objects with rate/value/avg keys.
+    int jsonIntValue(const QJsonValue& value, int defaultValue = 0)
+    {
+        if (value.isDouble()) {
+            return value.toInt();
+        }
+
+        if (value.isString()) {
+            const QString text = value.toString().trimmed();
+            bool ok = false;
+            const int intValue = text.toInt(&ok);
+            if (ok) {
+                return intValue;
+            }
+
+            const QString firstToken = text.section(' ', 0, 0);
+            const double doubleValue = firstToken.toDouble(&ok);
+            return ok ? static_cast<int>(doubleValue) : defaultValue;
+        }
+
+        if (value.isObject()) {
+            const QJsonObject object = value.toObject();
+            if (object.contains("rate")) {
+                return jsonIntValue(object.value("rate"), defaultValue);
+            }
+            if (object.contains("value")) {
+                return jsonIntValue(object.value("value"), defaultValue);
+            }
+            if (object.contains("avg")) {
+                return jsonIntValue(object.value("avg"), defaultValue);
+            }
+        }
+
+        return defaultValue;
+    }
+
+    // Convenience wrappers for nested lookups.
+    int jsonObjectInt(const QJsonObject& object, const QString& key, int defaultValue = 0)
+    {
+        return jsonIntValue(object.value(key), defaultValue);
+    }
+
+    // Convenience wrappers for nested lookups.
+    int jsonNestedInt(const QJsonObject& object, const QString& objectKey, const QString& valueKey, int defaultValue = 0)
+    {
+        const QJsonValue nestedValue = object.value(objectKey);
+        if (!nestedValue.isObject()) {
+            return defaultValue;
+        }
+
+        return jsonIntValue(nestedValue.toObject().value(valueKey), defaultValue);
+    }
+
+    // Safe array extraction.
+    QJsonArray jsonObjectArray(const QJsonObject& object, const QString& key)
+    {
+        const QJsonValue value = object.value(key);
+        return value.isArray() ? value.toArray() : QJsonArray{};
+    }
+
+    // Converts negative dBm to positive (takes qAbs).
+    int rawSignalToMagnitude(int rawSignal)
+    {
+        return qAbs(rawSignal);
+    }
+
+    // Simple signal - noise SNR calculation.
+    int snrFromSignalAndNoise(int signal, int noise)
+    {
+        if (signal == 0 && noise == 0) {
+            return 0;
+        }
+
+        return signal - noise;
+    }
+
+}
 
 const char* ARManager::_bbConn = "bb_conn"; //是否连接成功
 const char* ARManager::_brFreq = "br_freq"; //当前收发频段
@@ -33,6 +117,11 @@ const char* ARManager::_apiVersion = "api_ver";
 const char* ARManager::_is24G = "is_2.4G";
 const char* ARManager::_selfTemperature = "self_temperature";
 const char* ARManager::_skyTemperature = "sky_temperature";
+const char* ARManager::_signal = "signal";
+const char* ARManager::_noise = "noise";
+const char* ARManager::_bitrate = "bitrate";
+const char* ARManager::_channel = "channel";
+const char* ARManager::_frequency = "frequency";
 
 ARManager::ARManager(QGCApplication* app, QGCToolbox* toolbox)
     : QGCTool(app, toolbox)
@@ -80,6 +169,7 @@ ARManager::ARManager(QGCApplication* app, QGCToolbox* toolbox)
     }
     _deviceIP = ipStr;
     _connection = new ARConnection(ipStr);
+    _networkManager = new QNetworkAccessManager(this);
     // _connection->moveToThread(&workerThread);
     // connect(&workerThread, &QThread::finished, _connection, &QObject::deleteLater);
     // workerThread.start();
@@ -87,10 +177,15 @@ ARManager::ARManager(QGCApplication* app, QGCToolbox* toolbox)
     setMounted(_connection->isConnected());
     connect(_connection, &ARConnection::isConnectedChanged, this, &ARManager::setMounted);
     connect(_connection, &ARConnection::receivedMessage, this, &ARManager::_received_message);
+    connect(_networkManager, &QNetworkAccessManager::finished, this, &ARManager::_handleDoodleReply);
 
     _bindTimer.setSingleShot(true);
     _bindTimer.setInterval(140000);
     connect(&_bindTimer, &QTimer::timeout, this, &ARManager::_bindTimerout);
+
+    _doodlePollTimer.setSingleShot(false);
+    _doodlePollTimer.setInterval(1000);
+    connect(&_doodlePollTimer, &QTimer::timeout, this, &ARManager::_pollDoodleInfo);    // 1s interval, not single-shot
 }
 
 ARManager::~ARManager()
@@ -108,6 +203,7 @@ void ARManager::setToolbox(QGCToolbox* toolbox)
     if(_auto)
 #endif
     emit _connection->enable();
+    _doodlePollTimer.start();      // is called here, so polling begins at app startup.
 }
 
 void ARManager::pair()
@@ -148,6 +244,10 @@ void ARManager::enableRemote58G()
 
 void ARManager::_received_message(quint16 cmd, QByteArray message)
 {
+    if (_usingDoodleApi && cmd == AR_CMD_ID_REQUEST_INFO) {
+        return;
+    }   // bypass other communciation systems
+
     switch (cmd) {
     case AR_CMD_ID_REQUEST_INFO:
         _handle_device_info(message);
@@ -170,6 +270,10 @@ void ARManager::_received_message(quint16 cmd, QByteArray message)
 
 void ARManager::_handle_device_info(const QByteArray& message)
 {
+    if (_usingDoodleApi) {
+        return;
+    }   // bypass other communication systems
+
     if(message.size() != 0) {
         QString errorString;
         QJsonParseError jsonParseError;
@@ -228,6 +332,267 @@ void ARManager::_bindTimerout()
 {
     setBindTimeout(true);
     setBinding(false);
+}
+
+void ARManager::_pollDoodleInfo()  // pool loop
+{
+    if (_doodleRequestInFlight) {
+        return;
+    }
+
+    if (_rpcSession.isEmpty()) {
+        _requestDoodleLogin();
+    }
+    else {
+        _requestDoodleRadioInfo();
+    }
+}
+
+void ARManager::_requestDoodleLogin()  // ubus login
+{
+    const QUrl url(QString("https://%1/ubus/").arg(_doodleDeviceIP));
+    QNetworkRequest request(url);
+    request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
+    request.setTransferTimeout(800);
+
+    QSslConfiguration sslConfiguration = request.sslConfiguration();
+    sslConfiguration.setPeerVerifyMode(QSslSocket::VerifyNone);
+    request.setSslConfiguration(sslConfiguration);
+
+    const QJsonObject body{
+        { "jsonrpc", "2.0" },
+        { "id", 1 },
+        { "method", "call" },
+        { "params", QJsonArray{
+            "00000000000000000000000000000000",
+            "session",
+            "login",
+            QJsonObject{
+                { "username", "user" },
+                { "password", "DoodleSmartRadio" }
+            }
+        } }
+    };
+
+    QNetworkReply* reply = _networkManager->post(request, QJsonDocument(body).toJson(QJsonDocument::Compact));
+    reply->setProperty("doodleOp", "login");
+    reply->ignoreSslErrors();
+    _doodleRequestInFlight = true;
+}
+
+void ARManager::_requestDoodleRadioInfo()   // batched info request
+{
+    const QUrl url(QString("https://%1/ubus/").arg(_doodleDeviceIP));
+    QNetworkRequest request(url);
+    request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
+    request.setTransferTimeout(800);
+
+    QSslConfiguration sslConfiguration = request.sslConfiguration();
+    sslConfiguration.setPeerVerifyMode(QSslSocket::VerifyNone);
+    request.setSslConfiguration(sslConfiguration);
+
+    const QJsonArray body{
+        QJsonObject{
+            { "jsonrpc", "2.0" },
+            { "id", 1 },
+            { "method", "call" },
+            { "params", QJsonArray{
+                _rpcSession,
+                "iwinfo",
+                "info",
+                QJsonObject{
+                    { "device", "wlan0" }
+                }
+            } }
+        },
+        QJsonObject{
+            { "jsonrpc", "2.0" },
+            { "id", 2 },
+            { "method", "call" },
+            { "params", QJsonArray{
+                _rpcSession,
+                "iwinfo",
+                "assoclist",
+                QJsonObject{
+                    { "device", "wlan0" }
+                }
+            } }
+        }
+    };
+
+    QNetworkReply* reply = _networkManager->post(request, QJsonDocument(body).toJson(QJsonDocument::Compact));
+    reply->setProperty("doodleOp", "info");
+    reply->ignoreSslErrors();
+    _doodleRequestInFlight = true;
+}
+
+void ARManager::_handleDoodleReply(QNetworkReply* reply)  // response processing
+{
+    const QString operation = reply->property("doodleOp").toString();
+    const QByteArray payload = reply->readAll();
+    _doodleRequestInFlight = false;
+
+    //if (!payload.isEmpty()) {
+    //    qInfo().noquote() << QStringLiteral("[Doodle API][%1] %2")
+    //        .arg(operation, QString::fromUtf8(payload));
+    //}
+
+    if (reply->error() != QNetworkReply::NoError) {
+        qWarning() << "[Doodle API]" << operation << "failed:" << reply->errorString();
+        if (operation == "login" || operation == "info") {
+            _rpcSession.clear();
+            _setMountedFromDoodle(false);
+            if (_usingDoodleApi) {
+                setConnected(false);
+            }
+        }
+        reply->deleteLater();
+        return;
+    }
+
+    if (operation == "login") {
+        QJsonParseError parseError;
+        const QJsonDocument document = QJsonDocument::fromJson(payload, &parseError);
+        if (parseError.error == QJsonParseError::NoError && document.isObject()) {
+            const QJsonArray result = document.object().value("result").toArray();
+            if (result.count() > 1 && result.at(1).isObject()) {
+                const QString token = result.at(1).toObject().value("ubus_rpc_session").toString();
+                if (!token.isEmpty()) {
+                    qInfo() << "[Doodle API] login success, token acquired";
+                    _rpcSession = token;
+                    _usingDoodleApi = true;
+                    _setMountedFromDoodle(true);
+                    _requestDoodleRadioInfo();
+                }
+            }
+        }
+    }
+    else if (operation == "info") {
+        QJsonParseError parseError;
+        const QJsonDocument document = QJsonDocument::fromJson(payload, &parseError);
+        if (parseError.error == QJsonParseError::NoError && document.isArray()) {
+            const QJsonArray responses = document.array();
+            if (responses.count() >= 2) {
+                const QJsonArray infoResult = responses.at(0).toObject().value("result").toArray();
+                const QJsonArray assocResult = responses.at(1).toObject().value("result").toArray();
+                if (infoResult.count() > 1 && infoResult.at(1).isObject()) {
+                    const QJsonObject infoObject = infoResult.at(1).toObject();
+                    QJsonArray peers;
+                    if (assocResult.count() > 1 && assocResult.at(1).isObject()) {
+                        peers = assocResult.at(1).toObject().value("results").toArray();
+                    }
+
+                    const int localSignalRaw = jsonObjectInt(infoObject, _signal);
+                    const int localNoiseRaw = jsonObjectInt(infoObject, _noise);
+                    const QJsonArray localSignalAnts = jsonObjectArray(infoObject, "signal_ants");
+                    const int localRssiA = localSignalAnts.count() > 0
+                        ? rawSignalToMagnitude(jsonIntValue(localSignalAnts.at(0), localSignalRaw))
+                        : rawSignalToMagnitude(localSignalRaw);
+                    const int localRssiB = localSignalAnts.count() > 1
+                        ? rawSignalToMagnitude(jsonIntValue(localSignalAnts.at(1), localSignalRaw))
+                        : rawSignalToMagnitude(localSignalRaw);
+
+                    int peerSignalRaw = 0;
+                    int peerSignalAvgRaw = 0;
+                    int peerNoiseRaw = 0;
+                    int peerRxRate = 0;
+                    int peerTxRate = 0;
+                    int peerRssiA = 0;
+                    int peerRssiB = 0;
+
+                    // Find most active peer (skip stale > 5s)
+                    QJsonObject activePeer;
+                    bool hasActivePeer = false;
+                    for (int i = 0; i < peers.count(); ++i) {
+                        if (!peers.at(i).isObject()) continue;
+                        const QJsonObject p = peers.at(i).toObject();
+                        const int inactive = jsonObjectInt(p, "inactive");
+                        if (inactive > 5000) continue;
+                        if (!hasActivePeer || inactive < jsonObjectInt(activePeer, "inactive")) {
+                            activePeer = p;
+                            hasActivePeer = true;
+                        }
+                    }
+                    if (hasActivePeer) {
+                        const QJsonArray peerSignalAnts = jsonObjectArray(activePeer, "signal_ants");
+                        peerSignalRaw = jsonObjectInt(activePeer, _signal);
+                        peerSignalAvgRaw = jsonObjectInt(activePeer, "signal_avg");
+                        peerNoiseRaw = jsonObjectInt(activePeer, _noise);
+                        peerRxRate = jsonObjectInt(activePeer, "rx.rate", jsonNestedInt(activePeer, "rx", "rate"));
+                        peerTxRate = jsonObjectInt(activePeer, "tx.rate", jsonNestedInt(activePeer, "tx", "rate"));
+                        peerRssiA = peerSignalAnts.count() > 0
+                            ? rawSignalToMagnitude(jsonIntValue(peerSignalAnts.at(0), peerSignalRaw))
+                            : rawSignalToMagnitude(peerSignalRaw);
+                        peerRssiB = peerSignalAnts.count() > 1
+                            ? rawSignalToMagnitude(jsonIntValue(peerSignalAnts.at(1), peerSignalRaw))
+                            : rawSignalToMagnitude(peerSignalRaw);
+                    }
+
+                    _jsonObject[_bbConn] = hasActivePeer ? 1 : 0;
+                    _jsonObject[_aRssi] = localRssiA;
+                    _jsonObject[_bRssi] = localRssiB;
+                    _jsonObject[_aPeerSlotRssi] = peerRssiA;
+                    _jsonObject[_bPeerSlotRssi] = peerRssiB;
+                    _jsonObject[_snr] = snrFromSignalAndNoise(localSignalRaw, localNoiseRaw);
+                    _jsonObject[_peerSlotSnr] = snrFromSignalAndNoise(peerSignalRaw, peerNoiseRaw);
+                    _jsonObject[_slotTxBitRate] = jsonObjectInt(infoObject, _bitrate);
+                    _jsonObject[_targetBitRate] = peerRxRate > 0 ? peerRxRate : peerTxRate;
+                    _jsonObject[_slotTxFreq] = jsonObjectInt(infoObject, _frequency);
+                    _jsonObject[_slotRxFreq] = jsonObjectInt(infoObject, _frequency);
+                    _jsonObject[_brFreq] = jsonObjectInt(infoObject, _frequency);
+                    _jsonObject[_peerBrRssi0] = rawSignalToMagnitude(peerSignalRaw);
+                    _jsonObject[_peerBrRssi1] = rawSignalToMagnitude(peerSignalAvgRaw != 0 ? peerSignalAvgRaw : peerSignalRaw);
+                    _jsonObject[_peerBrSnr] = peerSignalAvgRaw != 0
+                        ? snrFromSignalAndNoise(peerSignalAvgRaw, peerNoiseRaw)
+                        : snrFromSignalAndNoise(peerSignalRaw, peerNoiseRaw);
+                    _jsonObject[_mcs] = 0;
+                    _jsonObject[_peerSlotMcs] = 0;
+                    _jsonObject[_is24G] = jsonObjectInt(infoObject, _frequency) < 3000 ? 1 : 0;
+                    _jsonObject[_apiVersion] = QStringLiteral("DoodleLabs ubus");
+                    _jsonObject[_selfTemperature] = 0;
+                    _jsonObject[_skyTemperature] = 0;
+
+                    _usingDoodleApi = true;
+                    _setMountedFromDoodle(true);
+                    setConnected(hasActivePeer);
+                    //qInfo() << "[Doodle API] info parsed"
+                    //    << "localSignalRaw:" << localSignalRaw
+                    //    << "localNoiseRaw:" << localNoiseRaw
+                    //    << "peerSignalRaw:" << peerSignalRaw
+                    //    << "peerSignalAvgRaw:" << peerSignalAvgRaw
+                    //    << "peerNoiseRaw:" << peerNoiseRaw
+                    //    << "peerCount:" << peers.count()
+                    //    << "connected:" << connected();
+                    if (connected() && _bindTimer.isActive() && (_bindTimer.remainingTime() < (_bindTimer.interval() - 15000))) {
+                        _bindTimer.stop();
+                        setBindTimeout(false);
+                        setBinding(false);
+                    }
+                    emit rssiChanged();
+                }
+            }
+        }
+    }
+
+    reply->deleteLater();
+}
+
+void ARManager::_handleLegacyMountedChanged(bool mounted)
+{
+    if (_usingDoodleApi) {
+        return;
+    }
+
+    setMounted(mounted);
+}
+
+void ARManager::_setMountedFromDoodle(bool mounted)
+{
+    if (!mounted && !_usingDoodleApi) {
+        return;
+    }
+
+    setMounted(mounted);
 }
 
 // void ARManager::_handle_osd_info(const QByteArray& message)

--- a/custom/src/ARLink/ARManager.h
+++ b/custom/src/ARLink/ARManager.h
@@ -136,7 +136,7 @@ private:
     QString _deviceIP;
     QNetworkAccessManager* _networkManager{nullptr};  // Core Qt object used to send HTTP network requests
     QTimer _doodlePollTimer;                            // Timer for periodically polling Doodle device status
-    QString _doodleDeviceIP{ "192.168.2.72" };          // Stores the current device IP address
+    QString _doodleDeviceIP;                              // Loaded from settings (default: 192.168.2.72)
     QString _rpcSession;                                // Session/token used for authenticated API communication
             
     static const char* _bbConn;

--- a/custom/src/ARLink/ARManager.h
+++ b/custom/src/ARLink/ARManager.h
@@ -1,6 +1,9 @@
 #pragma once
 #include <QThread>
 #include <QJsonObject>
+#include <QNetworkAccessManager>     // http client
+#include <QNetworkReply>             // response object
+#include <QTimer>                    // loop/pooling
 #include "QGCToolbox.h"
 #include "ARConnection.h"
 
@@ -16,6 +19,7 @@ public:
     bool                connected()     { return _connected; }
     bool                binding()       { return _binding; }
     bool                bindTimeout()   { return _bindTimeout; }
+    bool                 usingDoodleApi() const { return _usingDoodleApi; }
 
     Q_PROPERTY(QVariant rssiA           READ rssiA          NOTIFY rssiChanged)
     Q_PROPERTY(QVariant rssiB           READ rssiB          NOTIFY rssiChanged)
@@ -101,17 +105,27 @@ signals:
 
 private slots:
     void _received_message(quint16 cmd, QByteArray message);
+    // Methods
     void _bindTimerout();
+    void _pollDoodleInfo();                          // timer callback, decides login vs info request
+    void _handleDoodleReply(QNetworkReply* reply);   // prcoess all HTTP responses
+    void _handleLegacyMountedChanged(bool mounted);  // Prevents conflicting state updates between old and new systems
 
 private:
     void _handle_device_info(const QByteArray& message);
+    void _requestDoodleLogin();                     // sends ubus login post request
+    void _requestDoodleRadioInfo();                 // sends request for radio status signal      
+    void _setMountedFromDoodle(bool mounted);       // sends api coming result to internal state
     // void _handle_osd_info(const QByteArray& message);
 
+    // variables
     bool                _mounted{false};
     bool                _connected{false};
     bool                _auto{false};
     bool                _binding{false};
     bool                _bindTimeout{false};
+    bool                _usingDoodleApi{false};        // falg to indicate doodle api usage
+    bool                _doodleRequestInFlight{false}; // prevents overlapping HTTP request
 
     bool                _pairTriggered{false};
 
@@ -120,7 +134,11 @@ private:
     QJsonObject _jsonObject;
     QTimer _bindTimer;
     QString _deviceIP;
-
+    QNetworkAccessManager* _networkManager{nullptr};  // Core Qt object used to send HTTP network requests
+    QTimer _doodlePollTimer;                            // Timer for periodically polling Doodle device status
+    QString _doodleDeviceIP{ "192.168.2.72" };          // Stores the current device IP address
+    QString _rpcSession;                                // Session/token used for authenticated API communication
+            
     static const char* _bbConn;
     static const char* _brFreq;
     static const char* _slotTxFreq;
@@ -149,4 +167,9 @@ private:
     static const char* _is24G;
     static const char* _selfTemperature;
     static const char* _skyTemperature;
+    static const char* _signal;
+    static const char* _noise;
+    static const char* _bitrate;
+    static const char* _channel;
+    static const char* _frequency;
 };

--- a/custom/src/ARLink/ARSettings.qml
+++ b/custom/src/ARLink/ARSettings.qml
@@ -23,7 +23,8 @@ Rectangle {
     property real _labelWidth:                  ScreenTools.defaultFontPixelWidth * 26
     property real _valueWidth:                  ScreenTools.defaultFontPixelWidth * 20
     property real _panelWidth:                  _root.width * _internalWidthRatio
-    property var arManager: CustomQmlInterface.arManager
+    property var arManager:                     CustomQmlInterface.arManager
+    property bool _isDoodle:                    arManager.version == "DoodleLabs ubus"
 
     readonly property real _internalWidthRatio:          0.8
 
@@ -78,16 +79,20 @@ Rectangle {
                             Layout.minimumWidth: _labelWidth
                         }
                         QGCLabel {
-                            text:           arManager.mounted ? qsTr("Connected") : qsTr("Not Connected")
-                            color:          arManager.mounted ? qgcPal.colorGreen : qgcPal.colorRed
+                            text:           _isDoodle ? (arManager.connected ? qsTr("Connected") : qsTr("Not Connected"))
+                                            : (arManager.mounted ? qsTr("Connected") : qsTr("Not Connected"))
+                            color:          _isDoodle ? (arManager.connected ? qgcPal.colorGreen : qgcPal.colorRed)
+                                            : (arManager.mounted ? qgcPal.colorGreen : qgcPal.colorRed)
                             Layout.minimumWidth: _valueWidth
                         }
                         QGCLabel {
                             text:           qsTr("Bind Status:")
+                            visible:        !_isDoodle
                             Layout.minimumWidth: _labelWidth
                         }
                         QGCLabel {
                             text:           arManager.connected ? qsTr("Binded") : qsTr("Not Binded")
+                            visible:        !_isDoodle
                             color:          arManager.connected ? qgcPal.colorGreen : qgcPal.colorRed
                             Layout.minimumWidth: _valueWidth
                         }
@@ -110,25 +115,25 @@ Rectangle {
                             text:           arManager.upRate / 1000 + " / " + arManager.flow / 1000 + " Kb"
                         }
 						QGCLabel {
-                            text:           qsTr("Ground/Air MCS:")
+                            text:           _isDoodle ? qsTr("Local/Peer MCS:") : qsTr("Ground/Air MCS:")
                         }
                         QGCLabel {
                             text:           arManager.mcs + " / " + arManager.skyMcs
                         }
                         QGCLabel {
-                            text:           qsTr("Ground/Air/BR SNR:")
+                            text:           _isDoodle ? qsTr("Local/Peer SNR:") : qsTr("Ground/Air/BR SNR:")
                         }
                         QGCLabel {
                             text:           arManager.snr + " / " + arManager.skySnr + " / " + arManager.brSnr
                         }
 						QGCLabel {
-                            text:           qsTr("Ground RSSI A/B:")
+                            text:           _isDoodle ? qsTr("Local RSSI A/B:") : qsTr("Ground RSSI A/B:")
                         }
                         QGCLabel {
                             text:           arManager.rssiA * -1 + " / " + arManager.rssiB * -1 + " dB"
                         }
                         QGCLabel {
-                            text:           qsTr("Air RSSI A/B:")
+                            text:           _isDoodle ? qsTr("Peer RSSI A/B:") : qsTr("Air RSSI A/B:")
                         }
                         QGCLabel {
                             text:           arManager.skyRssiA * -1 + " / " + arManager.skyRssiB * -1 + " dB"
@@ -141,9 +146,11 @@ Rectangle {
                         }
                         QGCLabel {
                             text:           qsTr("Temperature: G/A")
+                            visible:        !_isDoodle
                         }
                         QGCLabel {
                             text:           arManager.temperature + " / " + arManager.skyTemperature + " degC"
+                            visible:        !_isDoodle
                         }
                         QGCLabel {
                             text:           qsTr("Version:")
@@ -180,6 +187,7 @@ Rectangle {
             Item {
                 width:                      _panelWidth
                 height:                     groundSettingsLabel.height
+                visible:                    !_isDoodle
                 anchors.margins:            ScreenTools.defaultFontPixelWidth
                 anchors.horizontalCenter:   parent.horizontalCenter
                 QGCLabel {
@@ -190,6 +198,7 @@ Rectangle {
             }
             Rectangle {
                 height:                     groundSettingsGrid.height + (ScreenTools.defaultFontPixelHeight * 2)
+                visible:                    !_isDoodle
                 width:                      _panelWidth
                 color:                      qgcPal.windowShade
                 anchors.margins:            ScreenTools.defaultFontPixelWidth
@@ -253,6 +262,7 @@ Rectangle {
             Item {
                 width:                      _panelWidth
                 height:                     airSettingsLabel.height
+                visible:                    !_isDoodle
                 anchors.margins:            ScreenTools.defaultFontPixelWidth
                 anchors.horizontalCenter:   parent.horizontalCenter
                 QGCLabel {
@@ -264,6 +274,7 @@ Rectangle {
             Rectangle {
                 height:                     airSettingsGrid.height + (ScreenTools.defaultFontPixelHeight * 2)
                 width:                      _panelWidth
+                visible:                    !_isDoodle
                 color:                      qgcPal.windowShade
                 anchors.margins:            ScreenTools.defaultFontPixelWidth
                 anchors.horizontalCenter:   parent.horizontalCenter

--- a/custom/src/Custom.SettingsGroup.json
+++ b/custom/src/Custom.SettingsGroup.json
@@ -24,6 +24,12 @@
     "enumStrings":      "Disable",
     "enumValues":       "0",
     "default":          0
+},
+{
+    "name":             "doodleLabsIP",
+    "shortDesc":        "Doodle Labs IP Address",
+    "type":             "string",
+    "default":          "192.168.2.72"
 }
 ]
 }

--- a/custom/src/CustomPlugin.cc
+++ b/custom/src/CustomPlugin.cc
@@ -169,8 +169,11 @@ CustomPlugin::settingsPages()
             _addSettingsEntry(tr("M2Link"), "qrc:/qml/M2Settings.qml");
         }
         else {
-            qInfo() << "M2Manager is null";
-            _addSettingsEntry(tr("Enpulse"), "qrc:/qml/ARSettings.qml");
+            bool isDoodle = _qmlInterface && _qmlInterface->arManager()
+                && _qmlInterface->arManager()->usingDoodleApi();
+
+            qInfo() << "M2Manager is null, isDoodle:" << isDoodle;
+            _addSettingsEntry(isDoodle ? tr("DoodleLab") : tr("Enpulse"), "qrc:/qml/ARSettings.qml");
         }
         _addSettingsEntry(tr("GeoAwareness"), "qrc:/qml/geoFenceSettings.qml");
 #if defined(QT_DEBUG)

--- a/custom/src/CustomSettings.cc
+++ b/custom/src/CustomSettings.cc
@@ -8,6 +8,7 @@ DECLARE_SETTINGGROUP(Custom, "Custom")
 
 DECLARE_SETTINGSFACT(CustomSettings, is3DMap)
 DECLARE_SETTINGSFACT(CustomSettings, rtcmSource)
+DECLARE_SETTINGSFACT(CustomSettings, doodleLabsIP)
 
 DECLARE_SETTINGSFACT_NO_FUNC(CustomSettings, teamMode)
 {

--- a/custom/src/CustomSettings.h
+++ b/custom/src/CustomSettings.h
@@ -12,4 +12,5 @@ public:
     DEFINE_SETTINGFACT(is3DMap)
     DEFINE_SETTINGFACT(rtcmSource)
     DEFINE_SETTINGFACT(teamMode)
+    DEFINE_SETTINGFACT(doodleLabsIP)
 };

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -759,6 +759,17 @@ Rectangle {
                                     visible:    _remoteIDEnable.visible
                                     property Fact _remoteIDEnable: QGroundControl.settingsManager.remoteIDSettings.enable
                                 }
+
+                                RowLayout {
+                                    spacing: _margins
+                                    QGCLabel {
+                                        text: qsTr("Doodle Labs IP")
+                                    }
+                                    FactTextField {
+                                        Layout.preferredWidth:  _comboFieldWidth
+                                        fact:                   QGroundControl.corePlugin.settings.doodleLabsIP
+                                    }
+                                }
                             }
                         }
 

--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -86,7 +86,7 @@ Rectangle {
         QGCButton {
             id:                 disconnectButton
             text:               qsTr("Disconnect")
-            onClicked:          _activeVehicle.closeVehicle()
+            onClicked:          { if (_activeVehicle) _activeVehicle.closeVehicle() }  // guard: vehicle may be nulled by link-loss before click lands
             visible:            _activeVehicle && _communicationLost && currentToolbar === flyViewToolbar
         }
     }


### PR DESCRIPTION
- ARLinkIndicator: add _isDoodle property to switch UI between Doodle Labs and Enpulse
- Signal bar uses drone (peer) RSSI instead of ground radio RSSI for Doodle Labs
- Signal strength thresholds calibrated for Doodle Labs dBm scale (30-95 range)
- Labels switch to "DoodleLab" / "Peer RSSI:" when Doodle API is active
- Hide "Start Pair" button for Doodle Labs (no Enpulse-style binding)
- ARSettings: add _isDoodle property, hide Bind Status / Temperature / Ground Settings for Doodle
- ARManager: add usingDoodleApi() getter, read MCS from peer assoclist
- CustomPlugin: settings entry label switches between "DoodleLab" and "Enpulse"
- MainToolBar: add null guard on Disconnect button to prevent crash during link-loss race

