### PR TITLE
task 7764 Add Android Rajant BCAPI discovery and signal display support

### DIFF
--- a/custom/qgroundcontrol.qrc
+++ b/custom/qgroundcontrol.qrc
@@ -13,6 +13,7 @@
 		<file alias="ModeIndicator.qml">../src/ui/toolbar/ModeIndicator.qml</file>
 		<file alias="MultiVehicleSelector.qml">../src/ui/toolbar/MultiVehicleSelector.qml</file>
 		<file alias="RCRSSIIndicator.qml">../src/ui/toolbar/RCRSSIIndicator.qml</file>
+		<file alias="RajantLinkIndicator.qml">../src/RajantLink/RajantLinkIndicator.qml</file>
 		<file alias="ROIIndicator.qml">../src/ui/toolbar/ROIIndicator.qml</file>
 		<file alias="TelemetryRSSIIndicator.qml">../src/ui/toolbar/TelemetryRSSIIndicator.qml</file>
 		<file alias="VTOLModeIndicator.qml">../src/ui/toolbar/VTOLModeIndicator.qml</file>
@@ -53,6 +54,7 @@
 		<file alias="GeneralSettings.qml">../src/ui/preferences/GeneralSettings.qml</file>
 		<file alias="CodevCameraVisual.qml">../src/Camera/CodevCameraVisual.qml</file>
 		<file alias="M2Settings.qml">../src/M2Link/M2Settings.qml</file>
+		<file alias="RajantSettings.qml">../src/RajantLink/RajantSettings.qml</file>
 		<!--<flie alias="QGCBusyIndicator.qml">../src/QmlControls/QGCBusyIndicator.qml</flie> -->
 		<file alias="QGroundControl/Controls/PseudocolorBar.qml">../src/QmlControls/PseudocolorBar.qml</file>
 		<file alias="QGroundControl/Controls/TouchSelectArea.qml">../src/QmlControls/TouchSelectArea.qml</file>
@@ -91,6 +93,7 @@
 		<file alias="PlanToolBar.qml">../src/PlanView/PlanToolBar.qml</file>
 		<file alias="PlanToolBarIndicators.qml">../src/PlanView/PlanToolBarIndicators.qml</file>
 		<file alias="M2LinkIndicator.qml">../src/M2Link/M2LinkIndicator.qml</file>
+		<file alias="RajantLinkIndicator.qml">../src/RajantLink/RajantLinkIndicator.qml</file>
 		<file alias="QGCDelayButton.qml">../src/QmlControls/QGCDelayButton.qml</file>
 		<file alias="PlanView.qml">../src/PlanView/PlanView.qml</file>
 		<file alias="GeoZoneMakeView.qml">../src/PlanView/GeoZoneMakeView.qml</file>

--- a/custom/src/ARLink/ARManager.cpp
+++ b/custom/src/ARLink/ARManager.cpp
@@ -351,7 +351,7 @@ void ARManager::_bindTimerout()
 
 void ARManager::_pollDoodleInfo()  // pool loop
 {
-    if (_doodleRequestInFlight) {
+    if (_doodlePollingStopped || _doodleRequestInFlight) {
         return;
     }
 
@@ -361,6 +361,14 @@ void ARManager::_pollDoodleInfo()  // pool loop
     else {
         _requestDoodleRadioInfo();
     }
+}
+
+void ARManager::stopDoodlePolling(const char* reason)
+{
+    if (_doodlePollingStopped) return;
+    _doodlePollingStopped = true;
+    _doodlePollTimer.stop();
+    qInfo() << "[Doodle API] polling stopped:" << (reason ? reason : "");
 }
 
 void ARManager::_requestDoodleLogin()  // ubus login
@@ -453,17 +461,34 @@ void ARManager::_handleDoodleReply(QNetworkReply* reply)  // response processing
     //}
 
     if (reply->error() != QNetworkReply::NoError) {
-        qWarning() << "[Doodle API]" << operation << "failed:" << reply->errorString();
+        // Log only the first failure, then stay silent — otherwise this spams the
+        // console every 800ms when no Doodle hardware is present on the LAN.
+        if (_doodleConsecutiveFailures == 0) {
+            qWarning() << "[Doodle API]" << operation << "failed:" << reply->errorString()
+                       << "(further failures silenced)";
+        }
         if (operation == "login" || operation == "info") {
             _rpcSession.clear();
             _setMountedFromDoodle(false);
             if (_usingDoodleApi) {
                 setConnected(false);
             }
+            _doodleConsecutiveFailures++;
+            // After N consecutive login failures assume no Doodle hardware and stop
+            // polling permanently. Avoids burning SSL handshakes and — critically —
+            // avoids the QNetworkReplyHttpImpl transferTimeout race that has been
+            // observed to cause heap corruption (0xc0000374) in Qt 5.15.2.
+            constexpr int kMaxConsecutiveFailures = 10;
+            if (!_doodlePollingStopped &&
+                _doodleConsecutiveFailures >= kMaxConsecutiveFailures &&
+                !_usingDoodleApi) {
+                stopDoodlePolling("no Doodle hardware detected after repeated failures");
+            }
         }
         reply->deleteLater();
         return;
     }
+    _doodleConsecutiveFailures = 0;
 
     if (operation == "login") {
         QJsonParseError parseError;

--- a/custom/src/ARLink/ARManager.cpp
+++ b/custom/src/ARLink/ARManager.cpp
@@ -351,7 +351,7 @@ void ARManager::_bindTimerout()
 
 void ARManager::_pollDoodleInfo()  // pool loop
 {
-    if (_doodlePollingStopped || _doodleRequestInFlight) {
+    if (_doodleRequestInFlight) {
         return;
     }
 
@@ -361,14 +361,6 @@ void ARManager::_pollDoodleInfo()  // pool loop
     else {
         _requestDoodleRadioInfo();
     }
-}
-
-void ARManager::stopDoodlePolling(const char* reason)
-{
-    if (_doodlePollingStopped) return;
-    _doodlePollingStopped = true;
-    _doodlePollTimer.stop();
-    qInfo() << "[Doodle API] polling stopped:" << (reason ? reason : "");
 }
 
 void ARManager::_requestDoodleLogin()  // ubus login
@@ -461,34 +453,17 @@ void ARManager::_handleDoodleReply(QNetworkReply* reply)  // response processing
     //}
 
     if (reply->error() != QNetworkReply::NoError) {
-        // Log only the first failure, then stay silent — otherwise this spams the
-        // console every 800ms when no Doodle hardware is present on the LAN.
-        if (_doodleConsecutiveFailures == 0) {
-            qWarning() << "[Doodle API]" << operation << "failed:" << reply->errorString()
-                       << "(further failures silenced)";
-        }
+        qWarning() << "[Doodle API]" << operation << "failed:" << reply->errorString();
         if (operation == "login" || operation == "info") {
             _rpcSession.clear();
             _setMountedFromDoodle(false);
             if (_usingDoodleApi) {
                 setConnected(false);
             }
-            _doodleConsecutiveFailures++;
-            // After N consecutive login failures assume no Doodle hardware and stop
-            // polling permanently. Avoids burning SSL handshakes and — critically —
-            // avoids the QNetworkReplyHttpImpl transferTimeout race that has been
-            // observed to cause heap corruption (0xc0000374) in Qt 5.15.2.
-            constexpr int kMaxConsecutiveFailures = 10;
-            if (!_doodlePollingStopped &&
-                _doodleConsecutiveFailures >= kMaxConsecutiveFailures &&
-                !_usingDoodleApi) {
-                stopDoodlePolling("no Doodle hardware detected after repeated failures");
-            }
         }
         reply->deleteLater();
         return;
     }
-    _doodleConsecutiveFailures = 0;
 
     if (operation == "login") {
         QJsonParseError parseError;

--- a/custom/src/ARLink/ARManager.cpp
+++ b/custom/src/ARLink/ARManager.cpp
@@ -351,8 +351,32 @@ void ARManager::_bindTimerout()
 
 void ARManager::_pollDoodleInfo()  // pool loop
 {
+    if (_doodlePollingStopped) {
+        return;
+    }
     if (_doodleRequestInFlight) {
         return;
+    }
+
+    // Doodle hardware is mutually exclusive with Enpulse M1, Enpulse M2, and
+    // Rajant on the same LAN. If any of those links has already come up, stop
+    // wasting HTTPS attempts trying to log in to a Doodle that isn't there.
+    //   - Enpulse M1 is active when our own ARConnection reports connected
+    //     while _usingDoodleApi is still false (shared _connected flag).
+    //   - M2 and Rajant are owned by CustomPlugin, so we ask the plugin.
+    if (_connected && !_usingDoodleApi) {
+        _stopDoodlePolling("Enpulse M1 connected");
+        return;
+    }
+    if (CustomPlugin* plugin = dynamic_cast<CustomPlugin*>(_toolbox->corePlugin())) {
+        if (plugin->m2Manager() != nullptr) {
+            _stopDoodlePolling("Enpulse M2 connected");
+            return;
+        }
+        if (plugin->rajantManager() != nullptr) {
+            _stopDoodlePolling("Rajant connected");
+            return;
+        }
     }
 
     if (_rpcSession.isEmpty()) {
@@ -361,6 +385,14 @@ void ARManager::_pollDoodleInfo()  // pool loop
     else {
         _requestDoodleRadioInfo();
     }
+}
+
+void ARManager::_stopDoodlePolling(const char* reason)
+{
+    if (_doodlePollingStopped) return;
+    _doodlePollingStopped = true;
+    _doodlePollTimer.stop();
+    qCInfo(ARManagerLog) << "[Doodle API] polling stopped:" << (reason ? reason : "");
 }
 
 void ARManager::_requestDoodleLogin()  // ubus login

--- a/custom/src/ARLink/ARManager.h
+++ b/custom/src/ARLink/ARManager.h
@@ -94,11 +94,6 @@ public:
     Q_INVOKABLE void enableRemote24G();
     Q_INVOKABLE void enableRemote58G();
 
-    // Permanently stops Doodle API polling. Called when another radio link
-    // (Rajant / M2) is detected — avoids continuous failed HTTPS requests
-    // that have been observed to cause heap corruption in Qt 5.15.2.
-    void stopDoodlePolling(const char* reason);
-
 signals:
     void                mountedChanged();
     void                connectedChanged();
@@ -131,8 +126,6 @@ private:
     bool                _bindTimeout{false};
     bool                _usingDoodleApi{false};        // falg to indicate doodle api usage
     bool                _doodleRequestInFlight{false}; // prevents overlapping HTTP request
-    bool                _doodlePollingStopped{false}; // true once stopDoodlePolling() has been called
-    int                 _doodleConsecutiveFailures{0};
 
     bool                _pairTriggered{false};
 

--- a/custom/src/ARLink/ARManager.h
+++ b/custom/src/ARLink/ARManager.h
@@ -114,7 +114,8 @@ private slots:
 private:
     void _handle_device_info(const QByteArray& message);
     void _requestDoodleLogin();                     // sends ubus login post request
-    void _requestDoodleRadioInfo();                 // sends request for radio status signal      
+    void _requestDoodleRadioInfo();                 // sends request for radio status signal
+    void _stopDoodlePolling(const char* reason);    // permanently stops Doodle polling (no auto-restart)
     void _setMountedFromDoodle(bool mounted);       // sends api coming result to internal state
     // void _handle_osd_info(const QByteArray& message);
 
@@ -126,6 +127,7 @@ private:
     bool                _bindTimeout{false};
     bool                _usingDoodleApi{false};        // falg to indicate doodle api usage
     bool                _doodleRequestInFlight{false}; // prevents overlapping HTTP request
+    bool                _doodlePollingStopped{false};  // true once Doodle polling has been permanently stopped
 
     bool                _pairTriggered{false};
 

--- a/custom/src/ARLink/ARManager.h
+++ b/custom/src/ARLink/ARManager.h
@@ -94,6 +94,11 @@ public:
     Q_INVOKABLE void enableRemote24G();
     Q_INVOKABLE void enableRemote58G();
 
+    // Permanently stops Doodle API polling. Called when another radio link
+    // (Rajant / M2) is detected — avoids continuous failed HTTPS requests
+    // that have been observed to cause heap corruption in Qt 5.15.2.
+    void stopDoodlePolling(const char* reason);
+
 signals:
     void                mountedChanged();
     void                connectedChanged();
@@ -126,6 +131,8 @@ private:
     bool                _bindTimeout{false};
     bool                _usingDoodleApi{false};        // falg to indicate doodle api usage
     bool                _doodleRequestInFlight{false}; // prevents overlapping HTTP request
+    bool                _doodlePollingStopped{false}; // true once stopDoodlePolling() has been called
+    int                 _doodleConsecutiveFailures{0};
 
     bool                _pairTriggered{false};
 

--- a/custom/src/CustomPlugin.cc
+++ b/custom/src/CustomPlugin.cc
@@ -36,6 +36,8 @@
 #include <QNetworkInterface>
 
 #if defined(Q_OS_ANDROID)
+#include <QtConcurrent>
+#include <QFutureWatcher>
 #include <sys/socket.h>
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
@@ -535,7 +537,7 @@ void CustomPlugin::_initRajantDiscovery()
 
     // Stop retrying after max attempts (no Rajant hardware present)
 #if defined(Q_OS_ANDROID)
-    static const int maxRetries = 5;   // 5 x 10s = 50 seconds
+    static const int maxRetries = 10;   // 10 x 10s = 100 seconds
 #else
     static const int maxRetries = 5;   // 5 x 10s = 50 seconds
 #endif
@@ -568,15 +570,36 @@ void CustomPlugin::_initRajantDiscovery()
     // Android: apps are sandboxed — "ip" command and /proc/net files are blocked.
     // Rajant BCAPI only listens on IPv6 link-local.
     //
-    // Strategy:
+    // Strategy (runs in background thread to avoid UI freeze):
     //   1. Find eth0/USB-Ethernet interface and its IPv4 gateway
     //   2. Send UDP poke to gateway to ensure ARP entry exists in kernel
     //   3. Send SUP multicast to discover Rajant nodes via their own protocol
     //   4. Query kernel neighbor table via Netlink to get MAC addresses
     //   5. Filter for Rajant OUI and construct fe80:: EUI-64 addresses
-    //   6. Probe TCP:2300 on candidates
+    //   6. Probe TCP:2300 on candidates (back on main thread)
 
     _rajantCandidates.clear();
+    // Run blocking discovery in background thread
+    auto* watcher = new QFutureWatcher<QStringList>(this);
+    connect(watcher, &QFutureWatcher<QStringList>::finished, this, [this, watcher]() {
+        QStringList candidates = watcher->result();
+        watcher->deleteLater();
+
+        _rajantCandidates = candidates;
+
+        if (_rajantCandidates.isEmpty()) {
+            qWarning() << "RajantDiscovery: no Rajant nodes found. Retrying in 10s...";
+            QTimer::singleShot(10000, this, &CustomPlugin::_initRajantDiscovery);
+            return;
+        }
+
+        qInfo() << "RajantDiscovery: probing" << _rajantCandidates.size() << "candidates via TCP:2300...";
+        _tryNextRajantCandidate();
+        });
+
+    watcher->setFuture(QtConcurrent::run([]() -> QStringList {
+    QStringList candidates;
+
     const auto interfaces = QNetworkInterface::allInterfaces();
 
     // --- Step 1: Find gateways and poke them via UDP to populate ARP cache ---
@@ -716,8 +739,8 @@ void CustomPlugin::_initRajantDiscovery()
             }
             if (!isResponse) continue;
 
-            if (!_rajantCandidates.contains(addr6)) {
-                _rajantCandidates.append(addr6);
+            if (!candidates.contains(addr6)) {
+                candidates.append(addr6);
                 qInfo() << "RajantDiscovery: SUP response from" << addr6;
             }
         }
@@ -730,7 +753,7 @@ void CustomPlugin::_initRajantDiscovery()
     // --- Step 2b: Identify the ground unit (Ethernet gateway's MAC) and put it first ---
     // The gateway on eth0 (not wlan0) is the directly-connected Rajant ground unit.
     // Match its MAC (from ARP/netlink) to the SUP fe80:: candidates.
-    if (_rajantCandidates.size() > 1 && !ethernetGatewayIPs.isEmpty()) {
+    if (candidates.size() > 1 && !ethernetGatewayIPs.isEmpty()) {
         qInfo() << "RajantDiscovery: identifying ground unit from ethernet gateways:" << ethernetGatewayIPs;
         int nlSock = socket(AF_NETLINK, SOCK_DGRAM, NETLINK_ROUTE);
         if (nlSock >= 0) {
@@ -783,10 +806,10 @@ void CustomPlugin::_initRajantDiscovery()
                             << "MAC -> ground unit fe80::" << groundPrefix;
 
                         // Move matching candidate to front of the list
-                        for (int i = 0; i < _rajantCandidates.size(); i++) {
-                            if (_rajantCandidates[i].startsWith(groundPrefix, Qt::CaseInsensitive)) {
-                                QString ground = _rajantCandidates.takeAt(i);
-                                _rajantCandidates.prepend(ground);
+                        for (int i = 0; i < candidates.size(); i++) {
+                            if (candidates[i].startsWith(groundPrefix, Qt::CaseInsensitive)) {
+                                QString ground = candidates.takeAt(i);
+                                candidates.prepend(ground);
                                 qInfo() << "RajantDiscovery: prioritized ground unit:" << ground;
                                 break;
                             }
@@ -799,7 +822,7 @@ void CustomPlugin::_initRajantDiscovery()
     }
 
     // --- Step 3: Netlink neighbor table fallback (if no SUP responses) ---
-    if (_rajantCandidates.isEmpty()) {
+    if (candidates.isEmpty()) {
         qInfo() << "RajantDiscovery: no SUP response, reading neighbor table via netlink...";
 
         int nlSock = socket(AF_NETLINK, SOCK_DGRAM, NETLINK_ROUTE);
@@ -867,8 +890,8 @@ void CustomPlugin::_initRajantDiscovery()
 
                         if (ndm->ndm_family == AF_INET6 && dstAddr) {
                             QString addr6 = QString("%1%%%2").arg(ipBuf, ifn);
-                            if (!_rajantCandidates.contains(addr6)) {
-                                _rajantCandidates.append(addr6);
+                            if (!candidates.contains(addr6)) {
+                                candidates.append(addr6);
                                 qInfo() << "RajantDiscovery: RAJANT IPv6:" << addr6;
                             }
                         }
@@ -892,8 +915,8 @@ void CustomPlugin::_initRajantDiscovery()
                                         QString sid = entry.ip().scopeId();
                                         if (sid.isEmpty()) sid = iface.name();
                                         QString addr6 = QString("%1%%%2").arg(euiBuf, sid);
-                                        if (!_rajantCandidates.contains(addr6)) {
-                                            _rajantCandidates.append(addr6);
+                                        if (!candidates.contains(addr6)) {
+                                            candidates.append(addr6);
                                             qInfo() << "RajantDiscovery: RAJANT ARP->IPv6:" << addr6
                                                 << "(from" << ipBuf << "MAC:" << mac << ")";
                                         }
@@ -915,14 +938,8 @@ void CustomPlugin::_initRajantDiscovery()
         }
     }
 
-    if (_rajantCandidates.isEmpty()) {
-        qWarning() << "RajantDiscovery: no Rajant nodes found. Retrying in 10s...";
-        QTimer::singleShot(10000, this, &CustomPlugin::_initRajantDiscovery);
-        return;
-    }
-
-    qInfo() << "RajantDiscovery: probing" << _rajantCandidates.size() << "candidates via TCP:2300...";
-    _tryNextRajantCandidate();
+    return candidates;
+    })); // end QtConcurrent::run lambda
 
 #else
     // Desktop: Query IPv6 neighbor table via system command

--- a/custom/src/CustomPlugin.cc
+++ b/custom/src/CustomPlugin.cc
@@ -34,7 +34,6 @@
 #include "QGroundControlQmlGlobal.h"
 #include <QFile>
 #include <QNetworkInterface>
-#include <QSet>
 
 #if defined(Q_OS_ANDROID)
 #include <QtConcurrent>
@@ -52,22 +51,6 @@
 QGC_LOGGING_CATEGORY(CustomLog, "CustomLog")
 
 static const char *kSlaveMode = "SlaveMode";
-
-// Identifies a Rajant node from its IPv6 link-local address by extracting the
-// last 3 bytes of the underlying MAC (which is identical across the node's
-// interfaces — only the OUI's U/L bit differs in EUI-64). Used to dedupe
-// netsh neighbor entries so we end up with exactly one candidate per physical
-// node (ground + air).
-//
-// Example: fe80::848d:84ff:feef:d84d  -> "efd84d"
-//          fe80::868d:84ff:feef:d84d  -> "efd84d"  (same node)
-//          fe80::848d:84ff:feef:e8d9  -> "efe8d9"  (different node)
-static QString rajantNodeId(const QString& addr)
-{
-    QString base = addr.section('%', 0, 0);
-    base.remove(':');
-    return base.right(6).toLower();
-}
 
 CustomFlyViewOptions::CustomFlyViewOptions(CustomOptions* options, QObject* parent)
     : QGCFlyViewOptions(options, parent)
@@ -502,9 +485,6 @@ QQmlApplicationEngine* CustomPlugin::createQmlApplicationEngine(QObject* parent)
                         qInfo() << "new M2Manager";
                         _m2Manager = new M2Manager(ipStr, this);
                         emit m2ManagerChanged();
-                        if (_qmlInterface && _qmlInterface->arManager()) {
-                            _qmlInterface->arManager()->stopDoodlePolling("M2 link detected");
-                        }
                     }
 
                     _m2boardcastSocket->disconnect();
@@ -544,109 +524,6 @@ void CustomPlugin::_initRajantDiscovery()
     //
     // Works on both Windows (netsh) and Android/Linux (ip -6 neigh).
 
-    // Ground connected — try to find air unit
-    if (_rajantManager != nullptr) {
-        if (_rajantAirManager != nullptr) return; // both connected, done
-        if (_rajantManager->peerCount() == 0) {
-            // Air unit not online yet, retry
-            QTimer::singleShot(10000, this, &CustomPlugin::_initRajantDiscovery);
-            return;
-        }
-
-        // Air unit is online — pick its address from the saved candidates.
-        // Match by node ID (last 3 MAC bytes) so two interfaces of the same
-        // Rajant aren't mistaken for two different nodes.
-        QString groundAddr  = _rajantManager->nodeAddress();
-        QString groundId    = rajantNodeId(groundAddr);
-        QString groundScope = groundAddr.section('%', 1);
-        QString airAddr;
-
-        for (const QString& candidate : _allRajantCandidates) {
-            if (rajantNodeId(candidate) == groundId) continue;
-            QString base = candidate.section('%', 0, 0);
-            airAddr = groundScope.isEmpty() ? base : base + "%" + groundScope;
-            break;
-        }
-
-#if defined(Q_OS_ANDROID)
-        if (airAddr.isEmpty()) {
-            qInfo() << "RajantDiscovery: peer detected, running SUP for air unit...";
-            QByteArray supReq;
-            supReq.append(BcapiProtocol::encodeTag(1, BcapiProtocol::VARINT));
-            supReq.append(BcapiProtocol::encodeVarint(0x73757000));
-            supReq.append(BcapiProtocol::encodeTag(2, BcapiProtocol::VARINT));
-            supReq.append(BcapiProtocol::encodeVarint(0));
-            QByteArray svc = "com.rajant.breadcrumb.v11";
-            supReq.append(BcapiProtocol::encodeTag(3, BcapiProtocol::LENGTH_DELIMITED));
-            supReq.append(BcapiProtocol::encodeVarint(svc.size()));
-            supReq.append(svc);
-
-            int sock = socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
-            if (sock >= 0) {
-                struct sockaddr_in6 bind6;
-                memset(&bind6, 0, sizeof(bind6));
-                bind6.sin6_family = AF_INET6;
-                bind6.sin6_addr = in6addr_any;
-                ::bind(sock, reinterpret_cast<struct sockaddr*>(&bind6), sizeof(bind6));
-                struct timeval tv = {2, 0};
-                setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
-
-                const auto ifaces = QNetworkInterface::allInterfaces();
-                for (const auto& iface : ifaces) {
-                    if (!(iface.flags() & QNetworkInterface::IsUp)) continue;
-                    if (iface.flags() & QNetworkInterface::IsLoopBack) continue;
-                    unsigned int idx = iface.index();
-                    if (idx == 0) continue;
-                    setsockopt(sock, IPPROTO_IPV6, IPV6_MULTICAST_IF, &idx, sizeof(idx));
-                    struct sockaddr_in6 dst;
-                    memset(&dst, 0, sizeof(dst));
-                    dst.sin6_family = AF_INET6;
-                    dst.sin6_port = htons(35057);
-                    dst.sin6_scope_id = idx;
-                    inet_pton(AF_INET6, "ff02::1", &dst.sin6_addr);
-                    sendto(sock, supReq.constData(), supReq.size(), 0,
-                           reinterpret_cast<struct sockaddr*>(&dst), sizeof(dst));
-                }
-                char buf[548];
-                struct sockaddr_in6 src;
-                while (true) {
-                    socklen_t slen = sizeof(src);
-                    ssize_t n = recvfrom(sock, buf, sizeof(buf), 0,
-                                         reinterpret_cast<struct sockaddr*>(&src), &slen);
-                    if (n <= 0) break;
-                    char ab[INET6_ADDRSTRLEN];
-                    inet_ntop(AF_INET6, &src.sin6_addr, ab, sizeof(ab));
-                    QString resp = QString::fromLatin1(ab);
-                    if (!resp.startsWith("fe80", Qt::CaseInsensitive)) continue;
-                    if (rajantNodeId(resp) == groundId) continue;
-                    char ifn[IF_NAMESIZE] = {};
-                    QString scope = (src.sin6_scope_id > 0 && if_indextoname(src.sin6_scope_id, ifn))
-                        ? QString::fromLatin1(ifn) : QString::number(src.sin6_scope_id);
-                    airAddr = resp + "%" + scope;
-                    break;
-                }
-                ::close(sock);
-            }
-        }
-#endif
-
-        if (airAddr.isEmpty()) {
-            qInfo() << "RajantDiscovery: air unit not found yet, retrying...";
-            QTimer::singleShot(10000, this, &CustomPlugin::_initRajantDiscovery);
-            return;
-        }
-
-        qInfo() << "RajantDiscovery: connecting to air unit:" << airAddr;
-        _rajantAirManager = new RajantManager(airAddr, _rajantPassword, this);
-        _rajantAirManager->setIsAirUnit(true);
-        emit rajantAirManagerChanged();
-        connect(_rajantAirManager, &RajantManager::firstStateReceived, this,
-            [airAddr](int airRadioCount) {
-                qInfo() << "=== Rajant Air Unit:" << airAddr << "Radios:" << airRadioCount << "===";
-        });
-        return;
-    }
-
     // Skip if another radio link is already connected — not a Rajant setup
     if (_m2Manager != nullptr) {
         qInfo() << "RajantDiscovery: M2 detected, skipping.";
@@ -684,9 +561,6 @@ void CustomPlugin::_initRajantDiscovery()
         qInfo() << "RajantDiscovery: using RAJANT_NODE env override:" << addr;
         _rajantManager = new RajantManager(addr, _rajantPassword, this);
         emit rajantManagerChanged();
-        if (_qmlInterface && _qmlInterface->arManager()) {
-            _qmlInterface->arManager()->stopDoodlePolling("Rajant env override set");
-        }
         return;
     }
 
@@ -711,18 +585,7 @@ void CustomPlugin::_initRajantDiscovery()
         QStringList candidates = watcher->result();
         watcher->deleteLater();
 
-        // Dedupe by node ID so two interfaces of the same Rajant collapse
-        // into one candidate — mirrors the Windows _onRajantScanFinished path.
-        QStringList unique;
-        QSet<QString> seenIds;
-        for (const QString& c : candidates) {
-            QString id = rajantNodeId(c);
-            if (id.isEmpty() || seenIds.contains(id)) continue;
-            seenIds.insert(id);
-            unique.append(c);
-        }
-        _rajantCandidates = unique;
-        _allRajantCandidates = unique; // saved for air-unit lookup after ground connects
+        _rajantCandidates = candidates;
 
         if (_rajantCandidates.isEmpty()) {
             qWarning() << "RajantDiscovery: no Rajant nodes found. Retrying in 10s...";
@@ -730,7 +593,6 @@ void CustomPlugin::_initRajantDiscovery()
             return;
         }
 
-        qInfo() << "RajantDiscovery: deduped to" << unique.size() << "unique node(s):" << unique;
         qInfo() << "RajantDiscovery: probing" << _rajantCandidates.size() << "candidates via TCP:2300...";
         _tryNextRajantCandidate();
         });
@@ -1157,23 +1019,6 @@ void CustomPlugin::_onRajantScanFinished(int exitCode, QProcess::ExitStatus exit
         return;
     }
 
-    // Dedupe by node ID (last 3 bytes of MAC). Different IPv6 link-locals
-    // can map to the same physical Rajant node — collapse them so we end up
-    // with at most one candidate per node (typically: ground + air = 2).
-    {
-        QStringList unique;
-        QSet<QString> seenIds;
-        for (const QString& c : _rajantCandidates) {
-            QString id = rajantNodeId(c);
-            if (id.isEmpty() || seenIds.contains(id)) continue;
-            seenIds.insert(id);
-            unique.append(c);
-        }
-        _rajantCandidates = unique;
-        _allRajantCandidates = unique; // kept for air-unit lookup after ground connects
-        qInfo() << "RajantDiscovery: deduped to" << unique.size() << "unique node(s):" << unique;
-    }
-
     // For Windows, we need to add the scope ID (interface index) to each candidate
     // Find all interfaces with fe80:: addresses and try each combination
 #if defined(Q_OS_WIN)
@@ -1263,56 +1108,17 @@ void CustomPlugin::_onRajantProbeConnected()
     // Ground unit's Peer.signal = signal ground receives from air (drone).
     // This is the RSSI value the pilot needs on the GCS toolbar.
     _rajantManager = new RajantManager(address, _rajantPassword, this);
-    if (_qmlInterface && _qmlInterface->arManager()) {
-        _qmlInterface->arManager()->stopDoodlePolling("Rajant ground unit detected");
-    }
-    
-    // Stop probing — ground is identified, air will be derived from
-    // _allRajantCandidates (saved during netsh dedup), not from re-probing.
     _rajantCandidates.clear();
     emit rajantManagerChanged();
 
     connect(_rajantManager, &RajantManager::firstStateReceived, this,
-        [this, address](int radioCount) {
+        [address](int radioCount) {
             qInfo() << "";
             qInfo() << "=== Rajant Discovery Complete ===";
             qInfo() << "  Ground unit:" << address;
             qInfo() << "  Radios:     " << radioCount;
             qInfo() << "  Displaying:  RSSI (ground <- air)";
             qInfo() << "";
-
-            if (_rajantAirManager != nullptr) return; // already created — guard against double-fire
-
-            // Pick the OTHER node from _allRajantCandidates (different node ID)
-            // and reach it via the ground's scope. Never use peer LinkLocal
-            // (%wlan0wds is internal to the Rajant node and unreachable).
-            QString groundId    = rajantNodeId(address);
-            QString groundScope = address.section('%', 1);
-            QString airAddr;
-            for (const QString& cand : _allRajantCandidates) {
-                if (rajantNodeId(cand) == groundId) continue;
-                QString cBase = cand.section('%', 0, 0);
-                airAddr = groundScope.isEmpty() ? cBase : cBase + "%" + groundScope;
-                break;
-            }
-            if (airAddr.isEmpty()) {
-                qInfo() << "RajantDiscovery: no second Rajant node discovered — air unit not connected.";
-                return;
-            }
-
-            qInfo() << "RajantDiscovery: connecting to air unit:" << airAddr;
-            _rajantAirManager = new RajantManager(airAddr, _rajantPassword, this);
-            _rajantAirManager->setIsAirUnit(true);
-            emit rajantAirManagerChanged();
-
-            connect(_rajantAirManager, &RajantManager::firstStateReceived, this,
-                [airAddr](int airRadioCount) {
-                    qInfo() << "";
-                    qInfo() << "=== Rajant Air Unit:" << airAddr << "===";
-                    qInfo() << "  Radios:" << airRadioCount;
-                    qInfo() << "  Displaying: RSSI (air <- ground)";
-                    qInfo() << "";
-            });
         });
 }
 

--- a/custom/src/CustomPlugin.cc
+++ b/custom/src/CustomPlugin.cc
@@ -36,8 +36,6 @@
 #include <QNetworkInterface>
 
 #if defined(Q_OS_ANDROID)
-#include <QtConcurrent>
-#include <QFutureWatcher>
 #include <sys/socket.h>
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
@@ -537,7 +535,7 @@ void CustomPlugin::_initRajantDiscovery()
 
     // Stop retrying after max attempts (no Rajant hardware present)
 #if defined(Q_OS_ANDROID)
-    static const int maxRetries = 10;   // 10 x 10s = 100 seconds
+    static const int maxRetries = 5;   // 5 x 10s = 50 seconds
 #else
     static const int maxRetries = 5;   // 5 x 10s = 50 seconds
 #endif
@@ -570,36 +568,15 @@ void CustomPlugin::_initRajantDiscovery()
     // Android: apps are sandboxed — "ip" command and /proc/net files are blocked.
     // Rajant BCAPI only listens on IPv6 link-local.
     //
-    // Strategy (runs in background thread to avoid UI freeze):
+    // Strategy:
     //   1. Find eth0/USB-Ethernet interface and its IPv4 gateway
     //   2. Send UDP poke to gateway to ensure ARP entry exists in kernel
     //   3. Send SUP multicast to discover Rajant nodes via their own protocol
     //   4. Query kernel neighbor table via Netlink to get MAC addresses
     //   5. Filter for Rajant OUI and construct fe80:: EUI-64 addresses
-    //   6. Probe TCP:2300 on candidates (back on main thread)
+    //   6. Probe TCP:2300 on candidates
 
     _rajantCandidates.clear();
-    // Run blocking discovery in background thread
-    auto* watcher = new QFutureWatcher<QStringList>(this);
-    connect(watcher, &QFutureWatcher<QStringList>::finished, this, [this, watcher]() {
-        QStringList candidates = watcher->result();
-        watcher->deleteLater();
-
-        _rajantCandidates = candidates;
-
-        if (_rajantCandidates.isEmpty()) {
-            qWarning() << "RajantDiscovery: no Rajant nodes found. Retrying in 10s...";
-            QTimer::singleShot(10000, this, &CustomPlugin::_initRajantDiscovery);
-            return;
-        }
-
-        qInfo() << "RajantDiscovery: probing" << _rajantCandidates.size() << "candidates via TCP:2300...";
-        _tryNextRajantCandidate();
-        });
-
-    watcher->setFuture(QtConcurrent::run([]() -> QStringList {
-    QStringList candidates;
-
     const auto interfaces = QNetworkInterface::allInterfaces();
 
     // --- Step 1: Find gateways and poke them via UDP to populate ARP cache ---
@@ -739,8 +716,8 @@ void CustomPlugin::_initRajantDiscovery()
             }
             if (!isResponse) continue;
 
-            if (!candidates.contains(addr6)) {
-                candidates.append(addr6);
+            if (!_rajantCandidates.contains(addr6)) {
+                _rajantCandidates.append(addr6);
                 qInfo() << "RajantDiscovery: SUP response from" << addr6;
             }
         }
@@ -753,7 +730,7 @@ void CustomPlugin::_initRajantDiscovery()
     // --- Step 2b: Identify the ground unit (Ethernet gateway's MAC) and put it first ---
     // The gateway on eth0 (not wlan0) is the directly-connected Rajant ground unit.
     // Match its MAC (from ARP/netlink) to the SUP fe80:: candidates.
-    if (candidates.size() > 1 && !ethernetGatewayIPs.isEmpty()) {
+    if (_rajantCandidates.size() > 1 && !ethernetGatewayIPs.isEmpty()) {
         qInfo() << "RajantDiscovery: identifying ground unit from ethernet gateways:" << ethernetGatewayIPs;
         int nlSock = socket(AF_NETLINK, SOCK_DGRAM, NETLINK_ROUTE);
         if (nlSock >= 0) {
@@ -806,10 +783,10 @@ void CustomPlugin::_initRajantDiscovery()
                             << "MAC -> ground unit fe80::" << groundPrefix;
 
                         // Move matching candidate to front of the list
-                        for (int i = 0; i < candidates.size(); i++) {
-                            if (candidates[i].startsWith(groundPrefix, Qt::CaseInsensitive)) {
-                                QString ground = candidates.takeAt(i);
-                                candidates.prepend(ground);
+                        for (int i = 0; i < _rajantCandidates.size(); i++) {
+                            if (_rajantCandidates[i].startsWith(groundPrefix, Qt::CaseInsensitive)) {
+                                QString ground = _rajantCandidates.takeAt(i);
+                                _rajantCandidates.prepend(ground);
                                 qInfo() << "RajantDiscovery: prioritized ground unit:" << ground;
                                 break;
                             }
@@ -822,7 +799,7 @@ void CustomPlugin::_initRajantDiscovery()
     }
 
     // --- Step 3: Netlink neighbor table fallback (if no SUP responses) ---
-    if (candidates.isEmpty()) {
+    if (_rajantCandidates.isEmpty()) {
         qInfo() << "RajantDiscovery: no SUP response, reading neighbor table via netlink...";
 
         int nlSock = socket(AF_NETLINK, SOCK_DGRAM, NETLINK_ROUTE);
@@ -890,8 +867,8 @@ void CustomPlugin::_initRajantDiscovery()
 
                         if (ndm->ndm_family == AF_INET6 && dstAddr) {
                             QString addr6 = QString("%1%%%2").arg(ipBuf, ifn);
-                            if (!candidates.contains(addr6)) {
-                                candidates.append(addr6);
+                            if (!_rajantCandidates.contains(addr6)) {
+                                _rajantCandidates.append(addr6);
                                 qInfo() << "RajantDiscovery: RAJANT IPv6:" << addr6;
                             }
                         }
@@ -915,8 +892,8 @@ void CustomPlugin::_initRajantDiscovery()
                                         QString sid = entry.ip().scopeId();
                                         if (sid.isEmpty()) sid = iface.name();
                                         QString addr6 = QString("%1%%%2").arg(euiBuf, sid);
-                                        if (!candidates.contains(addr6)) {
-                                            candidates.append(addr6);
+                                        if (!_rajantCandidates.contains(addr6)) {
+                                            _rajantCandidates.append(addr6);
                                             qInfo() << "RajantDiscovery: RAJANT ARP->IPv6:" << addr6
                                                 << "(from" << ipBuf << "MAC:" << mac << ")";
                                         }
@@ -938,8 +915,14 @@ void CustomPlugin::_initRajantDiscovery()
         }
     }
 
-    return candidates;
-    })); // end QtConcurrent::run lambda
+    if (_rajantCandidates.isEmpty()) {
+        qWarning() << "RajantDiscovery: no Rajant nodes found. Retrying in 10s...";
+        QTimer::singleShot(10000, this, &CustomPlugin::_initRajantDiscovery);
+        return;
+    }
+
+    qInfo() << "RajantDiscovery: probing" << _rajantCandidates.size() << "candidates via TCP:2300...";
+    _tryNextRajantCandidate();
 
 #else
     // Desktop: Query IPv6 neighbor table via system command

--- a/custom/src/CustomPlugin.cc
+++ b/custom/src/CustomPlugin.cc
@@ -34,6 +34,7 @@
 #include "QGroundControlQmlGlobal.h"
 #include <QFile>
 #include <QNetworkInterface>
+#include <QSet>
 
 #if defined(Q_OS_ANDROID)
 #include <QtConcurrent>
@@ -51,6 +52,22 @@
 QGC_LOGGING_CATEGORY(CustomLog, "CustomLog")
 
 static const char *kSlaveMode = "SlaveMode";
+
+// Identifies a Rajant node from its IPv6 link-local address by extracting the
+// last 3 bytes of the underlying MAC (which is identical across the node's
+// interfaces — only the OUI's U/L bit differs in EUI-64). Used to dedupe
+// netsh neighbor entries so we end up with exactly one candidate per physical
+// node (ground + air).
+//
+// Example: fe80::848d:84ff:feef:d84d  -> "efd84d"
+//          fe80::868d:84ff:feef:d84d  -> "efd84d"  (same node)
+//          fe80::848d:84ff:feef:e8d9  -> "efe8d9"  (different node)
+static QString rajantNodeId(const QString& addr)
+{
+    QString base = addr.section('%', 0, 0);
+    base.remove(':');
+    return base.right(6).toLower();
+}
 
 CustomFlyViewOptions::CustomFlyViewOptions(CustomOptions* options, QObject* parent)
     : QGCFlyViewOptions(options, parent)
@@ -485,6 +502,9 @@ QQmlApplicationEngine* CustomPlugin::createQmlApplicationEngine(QObject* parent)
                         qInfo() << "new M2Manager";
                         _m2Manager = new M2Manager(ipStr, this);
                         emit m2ManagerChanged();
+                        if (_qmlInterface && _qmlInterface->arManager()) {
+                            _qmlInterface->arManager()->stopDoodlePolling("M2 link detected");
+                        }
                     }
 
                     _m2boardcastSocket->disconnect();
@@ -524,6 +544,109 @@ void CustomPlugin::_initRajantDiscovery()
     //
     // Works on both Windows (netsh) and Android/Linux (ip -6 neigh).
 
+    // Ground connected — try to find air unit
+    if (_rajantManager != nullptr) {
+        if (_rajantAirManager != nullptr) return; // both connected, done
+        if (_rajantManager->peerCount() == 0) {
+            // Air unit not online yet, retry
+            QTimer::singleShot(10000, this, &CustomPlugin::_initRajantDiscovery);
+            return;
+        }
+
+        // Air unit is online — pick its address from the saved candidates.
+        // Match by node ID (last 3 MAC bytes) so two interfaces of the same
+        // Rajant aren't mistaken for two different nodes.
+        QString groundAddr  = _rajantManager->nodeAddress();
+        QString groundId    = rajantNodeId(groundAddr);
+        QString groundScope = groundAddr.section('%', 1);
+        QString airAddr;
+
+        for (const QString& candidate : _allRajantCandidates) {
+            if (rajantNodeId(candidate) == groundId) continue;
+            QString base = candidate.section('%', 0, 0);
+            airAddr = groundScope.isEmpty() ? base : base + "%" + groundScope;
+            break;
+        }
+
+#if defined(Q_OS_ANDROID)
+        if (airAddr.isEmpty()) {
+            qInfo() << "RajantDiscovery: peer detected, running SUP for air unit...";
+            QByteArray supReq;
+            supReq.append(BcapiProtocol::encodeTag(1, BcapiProtocol::VARINT));
+            supReq.append(BcapiProtocol::encodeVarint(0x73757000));
+            supReq.append(BcapiProtocol::encodeTag(2, BcapiProtocol::VARINT));
+            supReq.append(BcapiProtocol::encodeVarint(0));
+            QByteArray svc = "com.rajant.breadcrumb.v11";
+            supReq.append(BcapiProtocol::encodeTag(3, BcapiProtocol::LENGTH_DELIMITED));
+            supReq.append(BcapiProtocol::encodeVarint(svc.size()));
+            supReq.append(svc);
+
+            int sock = socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
+            if (sock >= 0) {
+                struct sockaddr_in6 bind6;
+                memset(&bind6, 0, sizeof(bind6));
+                bind6.sin6_family = AF_INET6;
+                bind6.sin6_addr = in6addr_any;
+                ::bind(sock, reinterpret_cast<struct sockaddr*>(&bind6), sizeof(bind6));
+                struct timeval tv = {2, 0};
+                setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+                const auto ifaces = QNetworkInterface::allInterfaces();
+                for (const auto& iface : ifaces) {
+                    if (!(iface.flags() & QNetworkInterface::IsUp)) continue;
+                    if (iface.flags() & QNetworkInterface::IsLoopBack) continue;
+                    unsigned int idx = iface.index();
+                    if (idx == 0) continue;
+                    setsockopt(sock, IPPROTO_IPV6, IPV6_MULTICAST_IF, &idx, sizeof(idx));
+                    struct sockaddr_in6 dst;
+                    memset(&dst, 0, sizeof(dst));
+                    dst.sin6_family = AF_INET6;
+                    dst.sin6_port = htons(35057);
+                    dst.sin6_scope_id = idx;
+                    inet_pton(AF_INET6, "ff02::1", &dst.sin6_addr);
+                    sendto(sock, supReq.constData(), supReq.size(), 0,
+                           reinterpret_cast<struct sockaddr*>(&dst), sizeof(dst));
+                }
+                char buf[548];
+                struct sockaddr_in6 src;
+                while (true) {
+                    socklen_t slen = sizeof(src);
+                    ssize_t n = recvfrom(sock, buf, sizeof(buf), 0,
+                                         reinterpret_cast<struct sockaddr*>(&src), &slen);
+                    if (n <= 0) break;
+                    char ab[INET6_ADDRSTRLEN];
+                    inet_ntop(AF_INET6, &src.sin6_addr, ab, sizeof(ab));
+                    QString resp = QString::fromLatin1(ab);
+                    if (!resp.startsWith("fe80", Qt::CaseInsensitive)) continue;
+                    if (rajantNodeId(resp) == groundId) continue;
+                    char ifn[IF_NAMESIZE] = {};
+                    QString scope = (src.sin6_scope_id > 0 && if_indextoname(src.sin6_scope_id, ifn))
+                        ? QString::fromLatin1(ifn) : QString::number(src.sin6_scope_id);
+                    airAddr = resp + "%" + scope;
+                    break;
+                }
+                ::close(sock);
+            }
+        }
+#endif
+
+        if (airAddr.isEmpty()) {
+            qInfo() << "RajantDiscovery: air unit not found yet, retrying...";
+            QTimer::singleShot(10000, this, &CustomPlugin::_initRajantDiscovery);
+            return;
+        }
+
+        qInfo() << "RajantDiscovery: connecting to air unit:" << airAddr;
+        _rajantAirManager = new RajantManager(airAddr, _rajantPassword, this);
+        _rajantAirManager->setIsAirUnit(true);
+        emit rajantAirManagerChanged();
+        connect(_rajantAirManager, &RajantManager::firstStateReceived, this,
+            [airAddr](int airRadioCount) {
+                qInfo() << "=== Rajant Air Unit:" << airAddr << "Radios:" << airRadioCount << "===";
+        });
+        return;
+    }
+
     // Skip if another radio link is already connected — not a Rajant setup
     if (_m2Manager != nullptr) {
         qInfo() << "RajantDiscovery: M2 detected, skipping.";
@@ -561,6 +684,9 @@ void CustomPlugin::_initRajantDiscovery()
         qInfo() << "RajantDiscovery: using RAJANT_NODE env override:" << addr;
         _rajantManager = new RajantManager(addr, _rajantPassword, this);
         emit rajantManagerChanged();
+        if (_qmlInterface && _qmlInterface->arManager()) {
+            _qmlInterface->arManager()->stopDoodlePolling("Rajant env override set");
+        }
         return;
     }
 
@@ -585,7 +711,18 @@ void CustomPlugin::_initRajantDiscovery()
         QStringList candidates = watcher->result();
         watcher->deleteLater();
 
-        _rajantCandidates = candidates;
+        // Dedupe by node ID so two interfaces of the same Rajant collapse
+        // into one candidate — mirrors the Windows _onRajantScanFinished path.
+        QStringList unique;
+        QSet<QString> seenIds;
+        for (const QString& c : candidates) {
+            QString id = rajantNodeId(c);
+            if (id.isEmpty() || seenIds.contains(id)) continue;
+            seenIds.insert(id);
+            unique.append(c);
+        }
+        _rajantCandidates = unique;
+        _allRajantCandidates = unique; // saved for air-unit lookup after ground connects
 
         if (_rajantCandidates.isEmpty()) {
             qWarning() << "RajantDiscovery: no Rajant nodes found. Retrying in 10s...";
@@ -593,6 +730,7 @@ void CustomPlugin::_initRajantDiscovery()
             return;
         }
 
+        qInfo() << "RajantDiscovery: deduped to" << unique.size() << "unique node(s):" << unique;
         qInfo() << "RajantDiscovery: probing" << _rajantCandidates.size() << "candidates via TCP:2300...";
         _tryNextRajantCandidate();
         });
@@ -1019,6 +1157,23 @@ void CustomPlugin::_onRajantScanFinished(int exitCode, QProcess::ExitStatus exit
         return;
     }
 
+    // Dedupe by node ID (last 3 bytes of MAC). Different IPv6 link-locals
+    // can map to the same physical Rajant node — collapse them so we end up
+    // with at most one candidate per node (typically: ground + air = 2).
+    {
+        QStringList unique;
+        QSet<QString> seenIds;
+        for (const QString& c : _rajantCandidates) {
+            QString id = rajantNodeId(c);
+            if (id.isEmpty() || seenIds.contains(id)) continue;
+            seenIds.insert(id);
+            unique.append(c);
+        }
+        _rajantCandidates = unique;
+        _allRajantCandidates = unique; // kept for air-unit lookup after ground connects
+        qInfo() << "RajantDiscovery: deduped to" << unique.size() << "unique node(s):" << unique;
+    }
+
     // For Windows, we need to add the scope ID (interface index) to each candidate
     // Find all interfaces with fe80:: addresses and try each combination
 #if defined(Q_OS_WIN)
@@ -1108,17 +1263,56 @@ void CustomPlugin::_onRajantProbeConnected()
     // Ground unit's Peer.signal = signal ground receives from air (drone).
     // This is the RSSI value the pilot needs on the GCS toolbar.
     _rajantManager = new RajantManager(address, _rajantPassword, this);
+    if (_qmlInterface && _qmlInterface->arManager()) {
+        _qmlInterface->arManager()->stopDoodlePolling("Rajant ground unit detected");
+    }
+    
+    // Stop probing — ground is identified, air will be derived from
+    // _allRajantCandidates (saved during netsh dedup), not from re-probing.
     _rajantCandidates.clear();
     emit rajantManagerChanged();
 
     connect(_rajantManager, &RajantManager::firstStateReceived, this,
-        [address](int radioCount) {
+        [this, address](int radioCount) {
             qInfo() << "";
             qInfo() << "=== Rajant Discovery Complete ===";
             qInfo() << "  Ground unit:" << address;
             qInfo() << "  Radios:     " << radioCount;
             qInfo() << "  Displaying:  RSSI (ground <- air)";
             qInfo() << "";
+
+            if (_rajantAirManager != nullptr) return; // already created — guard against double-fire
+
+            // Pick the OTHER node from _allRajantCandidates (different node ID)
+            // and reach it via the ground's scope. Never use peer LinkLocal
+            // (%wlan0wds is internal to the Rajant node and unreachable).
+            QString groundId    = rajantNodeId(address);
+            QString groundScope = address.section('%', 1);
+            QString airAddr;
+            for (const QString& cand : _allRajantCandidates) {
+                if (rajantNodeId(cand) == groundId) continue;
+                QString cBase = cand.section('%', 0, 0);
+                airAddr = groundScope.isEmpty() ? cBase : cBase + "%" + groundScope;
+                break;
+            }
+            if (airAddr.isEmpty()) {
+                qInfo() << "RajantDiscovery: no second Rajant node discovered — air unit not connected.";
+                return;
+            }
+
+            qInfo() << "RajantDiscovery: connecting to air unit:" << airAddr;
+            _rajantAirManager = new RajantManager(airAddr, _rajantPassword, this);
+            _rajantAirManager->setIsAirUnit(true);
+            emit rajantAirManagerChanged();
+
+            connect(_rajantAirManager, &RajantManager::firstStateReceived, this,
+                [airAddr](int airRadioCount) {
+                    qInfo() << "";
+                    qInfo() << "=== Rajant Air Unit:" << airAddr << "===";
+                    qInfo() << "  Radios:" << airRadioCount;
+                    qInfo() << "  Displaying: RSSI (air <- ground)";
+                    qInfo() << "";
+            });
         });
 }
 

--- a/custom/src/CustomPlugin.cc
+++ b/custom/src/CustomPlugin.cc
@@ -515,10 +515,12 @@ void CustomPlugin::_initRajantDiscovery()
     // Auto-discover Rajant nodes on the network.
     //
     // Method:
-    //   1. Query the IPv6 neighbor table for fe80:: link-local addresses
-    //   2. Filter by Rajant OUI MAC prefix (84:8D:84 or 86:8D:84)
-    //   3. Try TCP:2300 on each candidate to verify it's a BCAPI node
-    //   4. Connect to the first one that responds
+    //   1. Collect fe80:: link-local IPv6 neighbors (SUP multicast on Android,
+    //      system neighbor table on desktop, netlink fallback on Android).
+    //   2. Probe TCP:2300 on each candidate. The TCP probe is the real gate:
+    //      only Rajant BCAPI nodes listen on 2300, so non-Rajant neighbors
+    //      fall out naturally — no hardcoded MAC OUI list to maintain.
+    //   3. Connect to the first candidate that responds.
     //
     // Works on both Windows (netsh) and Android/Linux (ip -6 neigh).
 
@@ -573,7 +575,8 @@ void CustomPlugin::_initRajantDiscovery()
     //   2. Send UDP poke to gateway to ensure ARP entry exists in kernel
     //   3. Send SUP multicast to discover Rajant nodes via their own protocol
     //   4. Query kernel neighbor table via Netlink to get MAC addresses
-    //   5. Filter for Rajant OUI and construct fe80:: EUI-64 addresses
+    //   5. Construct fe80:: EUI-64 addresses from every neighbor MAC
+    //      (no OUI filter — TCP:2300 probe is the real gate)
     //   6. Probe TCP:2300 on candidates
 
     _rajantCandidates.clear();
@@ -860,16 +863,17 @@ void CustomPlugin::_initRajantDiscovery()
                         qInfo() << "RajantDiscovery: neigh" << ipBuf << "MAC:" << mac
                             << "iface:" << ifn << "family:" << ndm->ndm_family;
 
-                        // Check for Rajant OUI
-                        bool isRajant = ((macAddr[0] == 0x84 || macAddr[0] == 0x86) &&
-                            macAddr[1] == 0x8D && macAddr[2] == 0x84);
-                        if (!isRajant) continue;
+                        // No OUI filter: every fe80:: neighbor with a MAC is a candidate.
+                        // Non-Rajant devices will simply fail the TCP:2300 probe.
 
                         if (ndm->ndm_family == AF_INET6 && dstAddr) {
-                            QString addr6 = QString("%1%%%2").arg(ipBuf, ifn);
+                            // Only fe80:: link-local addresses can host a Rajant BCAPI peer
+                            QString ip6Str = QString::fromLatin1(ipBuf);
+                            if (!ip6Str.startsWith("fe80", Qt::CaseInsensitive)) continue;
+                            QString addr6 = QString("%1%%%2").arg(ip6Str, ifn);
                             if (!_rajantCandidates.contains(addr6)) {
                                 _rajantCandidates.append(addr6);
-                                qInfo() << "RajantDiscovery: RAJANT IPv6:" << addr6;
+                                qInfo() << "RajantDiscovery: candidate IPv6:" << addr6 << "MAC:" << mac;
                             }
                         }
                         else if (ndm->ndm_family == AF_INET && dstAddr) {
@@ -894,7 +898,7 @@ void CustomPlugin::_initRajantDiscovery()
                                         QString addr6 = QString("%1%%%2").arg(euiBuf, sid);
                                         if (!_rajantCandidates.contains(addr6)) {
                                             _rajantCandidates.append(addr6);
-                                            qInfo() << "RajantDiscovery: RAJANT ARP->IPv6:" << addr6
+                                            qInfo() << "RajantDiscovery: candidate ARP->IPv6:" << addr6
                                                 << "(from" << ipBuf << "MAC:" << mac << ")";
                                         }
                                         break;
@@ -956,9 +960,10 @@ void CustomPlugin::_onRajantScanFinished(int exitCode, QProcess::ExitStatus exit
         return;
     }
 
-    // Parse the output for fe80:: addresses with Rajant MAC OUI
-    // Rajant OUI: 84-8D-84 or 86-8D-84 (Windows format with dashes)
-    //             84:8d:84 or 86:8d:84 (Linux format with colons)
+    // Collect every fe80:: link-local neighbor as a candidate.
+    // We no longer filter by MAC OUI — the TCP:2300 probe is the real gate,
+    // so this works with any Rajant hardware variant (old, OEM, re-branded)
+    // regardless of which manufacturer prefix the MAC uses.
     _rajantCandidates.clear();
 
     const QStringList lines = output.split('\n');
@@ -966,14 +971,7 @@ void CustomPlugin::_onRajantScanFinished(int exitCode, QProcess::ExitStatus exit
         QString trimmed = line.trimmed();
         if (!trimmed.contains("fe80", Qt::CaseInsensitive)) continue;
 
-        // Check for Rajant MAC OUI
-        bool isRajant = trimmed.contains("84-8d-84", Qt::CaseInsensitive) ||
-            trimmed.contains("86-8d-84", Qt::CaseInsensitive) ||
-            trimmed.contains("84:8d:84", Qt::CaseInsensitive) ||
-            trimmed.contains("86:8d:84", Qt::CaseInsensitive);
-        if (!isRajant) continue;
-
-        // Check it's reachable (not "Unreachable")
+        // Skip entries the OS has marked as stale / unreachable
         if (trimmed.contains("Unreachable", Qt::CaseInsensitive)) continue;
 
         // Extract the fe80:: address
@@ -988,9 +986,11 @@ void CustomPlugin::_onRajantScanFinished(int exitCode, QProcess::ExitStatus exit
         // On Windows, we need to find the interface index for scoping
         // The address from netsh doesn't include the scope, we need to add it
         // We'll try connecting without scope first, then with detected interfaces
-        _rajantCandidates.append(ipv6Addr);
-        qInfo() << "RajantDiscovery: found Rajant node candidate:" << ipv6Addr
-            << "MAC:" << (parts.size() > 1 ? parts.at(1) : "unknown");
+        if (!_rajantCandidates.contains(ipv6Addr)) {
+            _rajantCandidates.append(ipv6Addr);
+            qInfo() << "RajantDiscovery: candidate:" << ipv6Addr
+                << "MAC:" << (parts.size() > 1 ? parts.at(1) : "unknown");
+        }
     }
 
     if (_rajantCandidates.isEmpty()) {

--- a/custom/src/CustomPlugin.cc
+++ b/custom/src/CustomPlugin.cc
@@ -34,6 +34,7 @@
 #include "QGroundControlQmlGlobal.h"
 #include <QFile>
 #include <QNetworkInterface>
+#include <QtConcurrent>
 
 #if defined(Q_OS_ANDROID)
 #include <sys/socket.h>
@@ -510,6 +511,25 @@ QQmlApplicationEngine* CustomPlugin::createQmlApplicationEngine(QObject* parent)
 
     return qmlEngine;
 }
+
+QString CustomPlugin::_activeNonRajantLinkName() const
+{
+    // Enpulse M2 — _m2Manager exists ⇒ M2 link is in use.
+    // Note: we treat existence as "in use" because M2Manager is only created
+    // after a discovery broadcast confirms an M2 board is on the network.
+    if (_m2Manager != nullptr) {
+        return QStringLiteral("Enpulse M2");
+    }
+    // Enpulse M1 / DoodleLab — same QObject (CustomQmlInterface::arManager),
+    // distinguished by the version string. Only block if it's actually connected.
+    if (_qmlInterface && _qmlInterface->arManager() &&
+        _qmlInterface->arManager()->connected()) {
+        const bool isDoodle = _qmlInterface->arManager()->usingDoodleApi();
+        return isDoodle ? QStringLiteral("DoodleLab") : QStringLiteral("Enpulse M1");
+    }
+    return QString();   // empty → no other link active, Rajant may proceed
+}
+
 void CustomPlugin::_initRajantDiscovery()
 {
     // Auto-discover Rajant nodes on the network.
@@ -524,14 +544,11 @@ void CustomPlugin::_initRajantDiscovery()
     //
     // Works on both Windows (netsh) and Android/Linux (ip -6 neigh).
 
-    // Skip if another radio link is already connected — not a Rajant setup
-    if (_m2Manager != nullptr) {
-        qInfo() << "RajantDiscovery: M2 detected, skipping.";
-        return;
-    }
-    if (_qmlInterface && _qmlInterface->arManager() &&
-        _qmlInterface->arManager()->connected()) {
-        qInfo() << "RajantDiscovery: Enpulse/DoodleLab detected, skipping.";
+    // Skip if another radio link is already connected — Rajant should never
+    // compete for the link with Enpulse M1/M2 or DoodleLab.
+    QString blocking = _activeNonRajantLinkName();
+    if (!blocking.isEmpty()) {
+        qInfo() << "RajantDiscovery:" << blocking << "is active — skipping Rajant scan.";
         return;
     }
 
@@ -570,17 +587,23 @@ void CustomPlugin::_initRajantDiscovery()
     // Android: apps are sandboxed — "ip" command and /proc/net files are blocked.
     // Rajant BCAPI only listens on IPv6 link-local.
     //
-    // Strategy:
+    // The blocking work (usleep pauses, recvfrom, netlink dumps) runs on a
+    // worker thread from Qt's thread pool — otherwise the UI would freeze
+    // for 1-3 s on every discovery attempt. Results are posted back to the
+    // main thread before we touch _rajantCandidates, schedule a retry, or
+    // start any QTcpSocket probes.
+    //
+    // Strategy (runs on worker thread):
     //   1. Find eth0/USB-Ethernet interface and its IPv4 gateway
     //   2. Send UDP poke to gateway to ensure ARP entry exists in kernel
     //   3. Send SUP multicast to discover Rajant nodes via their own protocol
     //   4. Query kernel neighbor table via Netlink to get MAC addresses
     //   5. Construct fe80:: EUI-64 addresses from every neighbor MAC
     //      (no OUI filter — TCP:2300 probe is the real gate)
-    //   6. Probe TCP:2300 on candidates
-
-    _rajantCandidates.clear();
-    const auto interfaces = QNetworkInterface::allInterfaces();
+    //   6. Probe TCP:2300 on candidates (on main thread, after marshalling)
+    QtConcurrent::run([this]() {
+        QStringList foundCandidates;
+        const auto interfaces = QNetworkInterface::allInterfaces();
 
     // --- Step 1: Find gateways and poke them via UDP to populate ARP cache ---
     // Track Ethernet (non-wlan) gateways separately — those are Rajant ground units
@@ -719,8 +742,8 @@ void CustomPlugin::_initRajantDiscovery()
             }
             if (!isResponse) continue;
 
-            if (!_rajantCandidates.contains(addr6)) {
-                _rajantCandidates.append(addr6);
+            if (!foundCandidates.contains(addr6)) {
+                foundCandidates.append(addr6);
                 qInfo() << "RajantDiscovery: SUP response from" << addr6;
             }
         }
@@ -733,7 +756,7 @@ void CustomPlugin::_initRajantDiscovery()
     // --- Step 2b: Identify the ground unit (Ethernet gateway's MAC) and put it first ---
     // The gateway on eth0 (not wlan0) is the directly-connected Rajant ground unit.
     // Match its MAC (from ARP/netlink) to the SUP fe80:: candidates.
-    if (_rajantCandidates.size() > 1 && !ethernetGatewayIPs.isEmpty()) {
+    if (foundCandidates.size() > 1 && !ethernetGatewayIPs.isEmpty()) {
         qInfo() << "RajantDiscovery: identifying ground unit from ethernet gateways:" << ethernetGatewayIPs;
         int nlSock = socket(AF_NETLINK, SOCK_DGRAM, NETLINK_ROUTE);
         if (nlSock >= 0) {
@@ -786,10 +809,10 @@ void CustomPlugin::_initRajantDiscovery()
                             << "MAC -> ground unit fe80::" << groundPrefix;
 
                         // Move matching candidate to front of the list
-                        for (int i = 0; i < _rajantCandidates.size(); i++) {
-                            if (_rajantCandidates[i].startsWith(groundPrefix, Qt::CaseInsensitive)) {
-                                QString ground = _rajantCandidates.takeAt(i);
-                                _rajantCandidates.prepend(ground);
+                        for (int i = 0; i < foundCandidates.size(); i++) {
+                            if (foundCandidates[i].startsWith(groundPrefix, Qt::CaseInsensitive)) {
+                                QString ground = foundCandidates.takeAt(i);
+                                foundCandidates.prepend(ground);
                                 qInfo() << "RajantDiscovery: prioritized ground unit:" << ground;
                                 break;
                             }
@@ -802,7 +825,7 @@ void CustomPlugin::_initRajantDiscovery()
     }
 
     // --- Step 3: Netlink neighbor table fallback (if no SUP responses) ---
-    if (_rajantCandidates.isEmpty()) {
+    if (foundCandidates.isEmpty()) {
         qInfo() << "RajantDiscovery: no SUP response, reading neighbor table via netlink...";
 
         int nlSock = socket(AF_NETLINK, SOCK_DGRAM, NETLINK_ROUTE);
@@ -871,8 +894,8 @@ void CustomPlugin::_initRajantDiscovery()
                             QString ip6Str = QString::fromLatin1(ipBuf);
                             if (!ip6Str.startsWith("fe80", Qt::CaseInsensitive)) continue;
                             QString addr6 = QString("%1%%%2").arg(ip6Str, ifn);
-                            if (!_rajantCandidates.contains(addr6)) {
-                                _rajantCandidates.append(addr6);
+                            if (!foundCandidates.contains(addr6)) {
+                                foundCandidates.append(addr6);
                                 qInfo() << "RajantDiscovery: candidate IPv6:" << addr6 << "MAC:" << mac;
                             }
                         }
@@ -896,8 +919,8 @@ void CustomPlugin::_initRajantDiscovery()
                                         QString sid = entry.ip().scopeId();
                                         if (sid.isEmpty()) sid = iface.name();
                                         QString addr6 = QString("%1%%%2").arg(euiBuf, sid);
-                                        if (!_rajantCandidates.contains(addr6)) {
-                                            _rajantCandidates.append(addr6);
+                                        if (!foundCandidates.contains(addr6)) {
+                                            foundCandidates.append(addr6);
                                             qInfo() << "RajantDiscovery: candidate ARP->IPv6:" << addr6
                                                 << "(from" << ipBuf << "MAC:" << mac << ")";
                                         }
@@ -919,14 +942,26 @@ void CustomPlugin::_initRajantDiscovery()
         }
     }
 
-    if (_rajantCandidates.isEmpty()) {
-        qWarning() << "RajantDiscovery: no Rajant nodes found. Retrying in 10s...";
-        QTimer::singleShot(10000, this, &CustomPlugin::_initRajantDiscovery);
-        return;
-    }
-
-    qInfo() << "RajantDiscovery: probing" << _rajantCandidates.size() << "candidates via TCP:2300...";
-    _tryNextRajantCandidate();
+        // Hand results back to the main thread for UI-touching work
+        // (QTcpSocket probes, QTimer scheduling, emitting signals).
+        QMetaObject::invokeMethod(this, [this, foundCandidates]() {
+            // Re-check: another link may have come online while the worker was running.
+            QString blocking = _activeNonRajantLinkName();
+            if (!blocking.isEmpty()) {
+                qInfo() << "RajantDiscovery:" << blocking
+                        << "came online during scan — discarding candidates.";
+                return;
+            }
+            _rajantCandidates = foundCandidates;
+            if (_rajantCandidates.isEmpty()) {
+                qWarning() << "RajantDiscovery: no Rajant nodes found. Retrying in 10s...";
+                QTimer::singleShot(10000, this, &CustomPlugin::_initRajantDiscovery);
+                return;
+            }
+            qInfo() << "RajantDiscovery: probing" << _rajantCandidates.size() << "candidates via TCP:2300...";
+            _tryNextRajantCandidate();
+        }, Qt::QueuedConnection);
+    }); // end QtConcurrent::run
 
 #else
     // Desktop: Query IPv6 neighbor table via system command
@@ -1037,6 +1072,15 @@ void CustomPlugin::_onRajantScanFinished(int exitCode, QProcess::ExitStatus exit
 
 void CustomPlugin::_tryNextRajantCandidate()
 {
+    // Re-check on every probe — another link may have come online between probes.
+    QString blocking = _activeNonRajantLinkName();
+    if (!blocking.isEmpty()) {
+        qInfo() << "RajantDiscovery:" << blocking
+                << "is active — aborting probe sequence.";
+        _rajantCandidates.clear();
+        return;
+    }
+
     if (_rajantCandidates.isEmpty()) {
         qInfo() << "RajantDiscovery: no candidates responded on TCP:2300."
             << "Retrying in 10 seconds...";

--- a/custom/src/CustomPlugin.cc
+++ b/custom/src/CustomPlugin.cc
@@ -1,4 +1,4 @@
-/****************************************************************************
+﻿/****************************************************************************
  *
  * (c) 2009-2019 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
  *
@@ -30,7 +30,21 @@
 #include "YS/YSManager.h"
 
 #include "M2Manager.h"
+#include "RajantManager.h"
 #include "QGroundControlQmlGlobal.h"
+#include <QFile>
+#include <QNetworkInterface>
+
+#if defined(Q_OS_ANDROID)
+#include <sys/socket.h>
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+#include <linux/neighbour.h>
+#include <net/if.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#include <cerrno>
+#endif
 
 QGC_LOGGING_CATEGORY(CustomLog, "CustomLog")
 
@@ -177,7 +191,13 @@ CustomPlugin::settingsPages()
                 && _qmlInterface->arManager()->usingDoodleApi();
 
             qInfo() << "M2Manager is null, isDoodle:" << isDoodle;
-            _addSettingsEntry(isDoodle ? tr("DoodleLab") : tr("Enpulse"), "qrc:/qml/ARSettings.qml");
+            // Show Rajant settings if available, otherwise Enpulse/DoodleLab
+            if (_rajantManager != nullptr) {
+                _addSettingsEntry(tr("Rajant"), "qrc:/qml/RajantSettings.qml");
+            }
+            else {
+                _addSettingsEntry(isDoodle ? tr("DoodleLab") : tr("Enpulse"), "qrc:/qml/ARSettings.qml");
+            }
         }
         _addSettingsEntry(tr("GeoAwareness"), "qrc:/qml/geoFenceSettings.qml");
 #if defined(QT_DEBUG)
@@ -477,9 +497,622 @@ QQmlApplicationEngine* CustomPlugin::createQmlApplicationEngine(QObject* parent)
         _m2boardcastSocket->deleteLater();
         _m2boardcastSocket = nullptr;
     }
+    // Initialize Rajant BCAPI connection
+    // Discovers Rajant nodes via IPv6 link-local neighbor scan,
+    // then connects via TCP:2300 for RSSI monitoring.
+    _initRajantDiscovery();
+
+    // Rebuild settings list when Rajant connects/disconnects
+    // so Rajant entry replaces Enpulse
+    connect(this, &CustomPlugin::rajantManagerChanged, this, [this]() {
+        _customSettingsList.clear();
+    });
 
     return qmlEngine;
 }
+void CustomPlugin::_initRajantDiscovery()
+{
+    // Auto-discover Rajant nodes on the network.
+    //
+    // Method:
+    //   1. Query the IPv6 neighbor table for fe80:: link-local addresses
+    //   2. Filter by Rajant OUI MAC prefix (84:8D:84 or 86:8D:84)
+    //   3. Try TCP:2300 on each candidate to verify it's a BCAPI node
+    //   4. Connect to the first one that responds
+    //
+    // Works on both Windows (netsh) and Android/Linux (ip -6 neigh).
+
+    // Skip if another radio link is already connected — not a Rajant setup
+    if (_m2Manager != nullptr) {
+        qInfo() << "RajantDiscovery: M2 detected, skipping.";
+        return;
+    }
+    if (_qmlInterface && _qmlInterface->arManager() &&
+        _qmlInterface->arManager()->connected()) {
+        qInfo() << "RajantDiscovery: Enpulse/DoodleLab detected, skipping.";
+        return;
+    }
+
+    // Stop retrying after max attempts (no Rajant hardware present)
+#if defined(Q_OS_ANDROID)
+    static const int maxRetries = 5;   // 5 x 10s = 50 seconds
+#else
+    static const int maxRetries = 5;   // 5 x 10s = 50 seconds
+#endif
+    if (_rajantDiscoveryRetries >= maxRetries) {
+        qInfo() << "RajantDiscovery: no Rajant hardware found after"
+            << _rajantDiscoveryRetries << "attempts. Stopping discovery.";
+        return;
+    }
+    _rajantDiscoveryRetries++;
+
+    // Allow password override via env var
+    QByteArray envPass = qgetenv("RAJANT_PASSWORD");
+    if (!envPass.isEmpty()) {
+        _rajantPassword = QString::fromUtf8(envPass);
+    }
+
+    // Allow manual override via env var (skips auto-discovery)
+    QByteArray envAddr = qgetenv("RAJANT_NODE");
+    if (!envAddr.isEmpty()) {
+        QString addr = QString::fromUtf8(envAddr);
+        qInfo() << "RajantDiscovery: using RAJANT_NODE env override:" << addr;
+        _rajantManager = new RajantManager(addr, _rajantPassword, this);
+        emit rajantManagerChanged();
+        return;
+    }
+
+    qInfo() << "RajantDiscovery: starting auto-discovery...";
+
+#if defined(Q_OS_ANDROID)
+    // Android: apps are sandboxed — "ip" command and /proc/net files are blocked.
+    // Rajant BCAPI only listens on IPv6 link-local.
+    //
+    // Strategy:
+    //   1. Find eth0/USB-Ethernet interface and its IPv4 gateway
+    //   2. Send UDP poke to gateway to ensure ARP entry exists in kernel
+    //   3. Send SUP multicast to discover Rajant nodes via their own protocol
+    //   4. Query kernel neighbor table via Netlink to get MAC addresses
+    //   5. Filter for Rajant OUI and construct fe80:: EUI-64 addresses
+    //   6. Probe TCP:2300 on candidates
+
+    _rajantCandidates.clear();
+    const auto interfaces = QNetworkInterface::allInterfaces();
+
+    // --- Step 1: Find gateways and poke them via UDP to populate ARP cache ---
+    // Track Ethernet (non-wlan) gateways separately — those are Rajant ground units
+    QStringList gatewayIPs;
+    QStringList ethernetGatewayIPs; // only eth0/usb etc, not wlan
+    for (const auto& iface : interfaces) {
+        if (!(iface.flags() & QNetworkInterface::IsUp)) continue;
+        if (iface.flags() & QNetworkInterface::IsLoopBack) continue;
+
+        qInfo() << "RajantDiscovery: interface" << iface.name()
+            << "index:" << iface.index() << "flags:" << iface.flags();
+
+        bool isWifi = iface.name().startsWith("wlan", Qt::CaseInsensitive) ||
+            iface.name().startsWith("wifi", Qt::CaseInsensitive);
+
+        for (const auto& entry : iface.addressEntries()) {
+            QHostAddress addr = entry.ip();
+            if (addr.protocol() != QAbstractSocket::IPv4Protocol) continue;
+            if (addr.isLoopback()) continue;
+            quint32 ip4 = addr.toIPv4Address();
+            quint32 mask = entry.netmask().toIPv4Address();
+            quint32 gw = (ip4 & mask) | 1;
+            if (gw == ip4) continue;
+            QString gwStr = QHostAddress(gw).toString();
+            qInfo() << "RajantDiscovery:" << iface.name() << "ip:" << addr.toString()
+                << "gateway:" << gwStr << (isWifi ? "(wifi)" : "(ethernet)");
+            if (!gatewayIPs.contains(gwStr))
+                gatewayIPs.append(gwStr);
+            if (!isWifi && !ethernetGatewayIPs.contains(gwStr))
+                ethernetGatewayIPs.append(gwStr);
+        }
+    }
+
+    // Poke each gateway with UDP to force ARP resolution — send twice for reliability
+    for (int attempt = 0; attempt < 2; attempt++) {
+        for (const QString& gw : gatewayIPs) {
+            int pokeSock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+            if (pokeSock >= 0) {
+                struct sockaddr_in dst;
+                memset(&dst, 0, sizeof(dst));
+                dst.sin_family = AF_INET;
+                dst.sin_port = htons(1);
+                inet_pton(AF_INET, gw.toLatin1().constData(), &dst.sin_addr);
+                char poke = 0;
+                sendto(pokeSock, &poke, 1, 0,
+                    reinterpret_cast<struct sockaddr*>(&dst), sizeof(dst));
+                ::close(pokeSock);
+            }
+        }
+        if (attempt == 0) usleep(100000); // 100ms between pokes
+    }
+    qInfo() << "RajantDiscovery: ARP poke sent to" << gatewayIPs;
+    // Wait for ARP to complete
+    usleep(500000); // 500ms
+
+    // --- Step 2: SUP multicast discovery (Rajant's own protocol) ---
+    // Send SUP REQUEST to ff02::1 port 35057 on all interfaces
+    QByteArray supRequest;
+    supRequest.append(BcapiProtocol::encodeTag(1, BcapiProtocol::VARINT));
+    supRequest.append(BcapiProtocol::encodeVarint(0x73757000));
+    supRequest.append(BcapiProtocol::encodeTag(2, BcapiProtocol::VARINT));
+    supRequest.append(BcapiProtocol::encodeVarint(0)); // REQUEST
+    QByteArray svcName = "com.rajant.breadcrumb.v11";
+    supRequest.append(BcapiProtocol::encodeTag(3, BcapiProtocol::LENGTH_DELIMITED));
+    supRequest.append(BcapiProtocol::encodeVarint(svcName.size()));
+    supRequest.append(svcName);
+    supRequest.append(BcapiProtocol::encodeTag(5, BcapiProtocol::VARINT));
+    supRequest.append(BcapiProtocol::encodeVarint(500));
+
+    int supSock = socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
+    if (supSock >= 0) {
+        struct sockaddr_in6 bindAddr;
+        memset(&bindAddr, 0, sizeof(bindAddr));
+        bindAddr.sin6_family = AF_INET6;
+        bindAddr.sin6_addr = in6addr_any;
+        ::bind(supSock, reinterpret_cast<struct sockaddr*>(&bindAddr), sizeof(bindAddr));
+
+        struct timeval tv = { 2, 0 }; // 2s receive timeout
+        setsockopt(supSock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+        for (const auto& iface : interfaces) {
+            if (!(iface.flags() & QNetworkInterface::IsUp)) continue;
+            if (iface.flags() & QNetworkInterface::IsLoopBack) continue;
+            unsigned int ifidx = iface.index();
+            if (ifidx == 0) continue;
+
+            setsockopt(supSock, IPPROTO_IPV6, IPV6_MULTICAST_IF, &ifidx, sizeof(ifidx));
+
+            struct sockaddr_in6 dst;
+            memset(&dst, 0, sizeof(dst));
+            dst.sin6_family = AF_INET6;
+            dst.sin6_port = htons(35057);
+            dst.sin6_scope_id = ifidx;
+            inet_pton(AF_INET6, "ff02::1", &dst.sin6_addr);
+
+            ssize_t sent = sendto(supSock, supRequest.constData(), supRequest.size(), 0,
+                reinterpret_cast<struct sockaddr*>(&dst), sizeof(dst));
+            qInfo() << "RajantDiscovery: SUP on" << iface.name()
+                << (sent > 0 ? "OK" : strerror(errno));
+        }
+
+        // Collect SUP responses
+        char respBuf[548];
+        struct sockaddr_in6 srcAddr;
+        while (true) {
+            socklen_t srcLen = sizeof(srcAddr);
+            ssize_t n = recvfrom(supSock, respBuf, sizeof(respBuf), 0,
+                reinterpret_cast<struct sockaddr*>(&srcAddr), &srcLen);
+            if (n <= 0) break;
+
+            char addrBuf[INET6_ADDRSTRLEN];
+            inet_ntop(AF_INET6, &srcAddr.sin6_addr, addrBuf, sizeof(addrBuf));
+            QString senderAddr = QString::fromLatin1(addrBuf);
+            if (!senderAddr.startsWith("fe80", Qt::CaseInsensitive)) continue;
+
+            char ifnameBuf[IF_NAMESIZE] = {};
+            QString ifname = (srcAddr.sin6_scope_id > 0 && if_indextoname(srcAddr.sin6_scope_id, ifnameBuf))
+                ? QString::fromLatin1(ifnameBuf) : QString::number(srcAddr.sin6_scope_id);
+            QString addr6 = senderAddr + "%" + ifname;
+
+            // Verify SUP RESPONSE (field 2 = 1)
+            QByteArray resp = QByteArray::fromRawData(respBuf, n);
+            int pos = 0;
+            bool isResponse = false;
+            while (pos < resp.size()) {
+                BcapiProtocol::Tag tag = BcapiProtocol::decodeTag(resp, pos);
+                if (tag.fieldNumber == 0) break;
+                if (tag.wireType == BcapiProtocol::VARINT) {
+                    quint64 val = BcapiProtocol::decodeVarint(resp, pos);
+                    if (tag.fieldNumber == 2 && val == 1) isResponse = true;
+                }
+                else if (tag.wireType == BcapiProtocol::LENGTH_DELIMITED) {
+                    pos += BcapiProtocol::decodeVarint(resp, pos);
+                }
+                else break;
+            }
+            if (!isResponse) continue;
+
+            if (!_rajantCandidates.contains(addr6)) {
+                _rajantCandidates.append(addr6);
+                qInfo() << "RajantDiscovery: SUP response from" << addr6;
+            }
+        }
+        ::close(supSock);
+    }
+    else {
+        qInfo() << "RajantDiscovery: UDP6 socket failed:" << strerror(errno);
+    }
+
+    // --- Step 2b: Identify the ground unit (Ethernet gateway's MAC) and put it first ---
+    // The gateway on eth0 (not wlan0) is the directly-connected Rajant ground unit.
+    // Match its MAC (from ARP/netlink) to the SUP fe80:: candidates.
+    if (_rajantCandidates.size() > 1 && !ethernetGatewayIPs.isEmpty()) {
+        qInfo() << "RajantDiscovery: identifying ground unit from ethernet gateways:" << ethernetGatewayIPs;
+        int nlSock = socket(AF_NETLINK, SOCK_DGRAM, NETLINK_ROUTE);
+        if (nlSock >= 0) {
+            struct { struct nlmsghdr nlh; struct ndmsg ndm; } req;
+            memset(&req, 0, sizeof(req));
+            req.nlh.nlmsg_len = sizeof(req);
+            req.nlh.nlmsg_type = RTM_GETNEIGH;
+            req.nlh.nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
+            req.nlh.nlmsg_seq = 1;
+            req.ndm.ndm_family = AF_INET;
+            if (::send(nlSock, &req, sizeof(req), 0) >= 0) {
+                char buf[16384];
+                bool nlDone = false;
+                while (!nlDone) {
+                    int len = ::recv(nlSock, buf, sizeof(buf), 0);
+                    if (len <= 0) break;
+                    for (struct nlmsghdr* nh = reinterpret_cast<struct nlmsghdr*>(buf);
+                        NLMSG_OK(nh, static_cast<unsigned>(len));
+                        nh = NLMSG_NEXT(nh, len)) {
+                        if (nh->nlmsg_type == NLMSG_DONE) { nlDone = true; break; }
+                        if (nh->nlmsg_type == NLMSG_ERROR) { nlDone = true; break; }
+                        if (nh->nlmsg_type != RTM_NEWNEIGH) continue;
+                        struct ndmsg* ndm = static_cast<struct ndmsg*>(NLMSG_DATA(nh));
+                        if (ndm->ndm_family != AF_INET) continue;
+                        unsigned char* macAddr = nullptr;
+                        void* dstAddr = nullptr;
+                        struct rtattr* rta = reinterpret_cast<struct rtattr*>(
+                            reinterpret_cast<char*>(ndm) + NLMSG_ALIGN(sizeof(*ndm)));
+                        int attrLen = nh->nlmsg_len - NLMSG_LENGTH(sizeof(*ndm));
+                        for (; RTA_OK(rta, attrLen); rta = RTA_NEXT(rta, attrLen)) {
+                            if (rta->rta_type == NDA_DST)    dstAddr = RTA_DATA(rta);
+                            if (rta->rta_type == NDA_LLADDR) macAddr = static_cast<unsigned char*>(RTA_DATA(rta));
+                        }
+                        if (!dstAddr || !macAddr) continue;
+                        char ip4Buf[INET_ADDRSTRLEN];
+                        inet_ntop(AF_INET, dstAddr, ip4Buf, sizeof(ip4Buf));
+                        if (!ethernetGatewayIPs.contains(QString::fromLatin1(ip4Buf))) continue;
+
+                        // Construct fe80:: EUI-64 from gateway MAC
+                        unsigned char eui[16] = { 0xfe,0x80,0,0,0,0,0,0,0,0,0,0,0,0,0,0 };
+                        eui[8] = macAddr[0] ^ 0x02;
+                        eui[9] = macAddr[1]; eui[10] = macAddr[2];
+                        eui[11] = 0xFF; eui[12] = 0xFE;
+                        eui[13] = macAddr[3]; eui[14] = macAddr[4]; eui[15] = macAddr[5];
+                        char euiBuf[INET6_ADDRSTRLEN];
+                        inet_ntop(AF_INET6, eui, euiBuf, sizeof(euiBuf));
+                        QString groundPrefix = QString::fromLatin1(euiBuf);
+
+                        qInfo() << "RajantDiscovery: gateway" << ip4Buf
+                            << "MAC -> ground unit fe80::" << groundPrefix;
+
+                        // Move matching candidate to front of the list
+                        for (int i = 0; i < _rajantCandidates.size(); i++) {
+                            if (_rajantCandidates[i].startsWith(groundPrefix, Qt::CaseInsensitive)) {
+                                QString ground = _rajantCandidates.takeAt(i);
+                                _rajantCandidates.prepend(ground);
+                                qInfo() << "RajantDiscovery: prioritized ground unit:" << ground;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+            ::close(nlSock);
+        }
+    }
+
+    // --- Step 3: Netlink neighbor table fallback (if no SUP responses) ---
+    if (_rajantCandidates.isEmpty()) {
+        qInfo() << "RajantDiscovery: no SUP response, reading neighbor table via netlink...";
+
+        int nlSock = socket(AF_NETLINK, SOCK_DGRAM, NETLINK_ROUTE);
+        if (nlSock >= 0) {
+            struct { struct nlmsghdr nlh; struct ndmsg ndm; } req;
+            memset(&req, 0, sizeof(req));
+            req.nlh.nlmsg_len = sizeof(req);
+            req.nlh.nlmsg_type = RTM_GETNEIGH;
+            req.nlh.nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
+            req.nlh.nlmsg_seq = 1;
+            req.ndm.ndm_family = AF_UNSPEC;
+
+            if (::send(nlSock, &req, sizeof(req), 0) >= 0) {
+                char buf[16384];
+                bool nlDone = false;
+                while (!nlDone) {
+                    int len = ::recv(nlSock, buf, sizeof(buf), 0);
+                    if (len <= 0) break;
+                    for (struct nlmsghdr* nh = reinterpret_cast<struct nlmsghdr*>(buf);
+                        NLMSG_OK(nh, static_cast<unsigned>(len));
+                        nh = NLMSG_NEXT(nh, len)) {
+                        if (nh->nlmsg_type == NLMSG_DONE) { nlDone = true; break; }
+                        if (nh->nlmsg_type == NLMSG_ERROR) { nlDone = true; break; }
+                        if (nh->nlmsg_type != RTM_NEWNEIGH) continue;
+
+                        struct ndmsg* ndm = static_cast<struct ndmsg*>(NLMSG_DATA(nh));
+                        unsigned char* macAddr = nullptr;
+                        int macLen = 0;
+                        void* dstAddr = nullptr;
+                        struct rtattr* rta = reinterpret_cast<struct rtattr*>(
+                            reinterpret_cast<char*>(ndm) + NLMSG_ALIGN(sizeof(*ndm)));
+                        int attrLen = nh->nlmsg_len - NLMSG_LENGTH(sizeof(*ndm));
+                        for (; RTA_OK(rta, attrLen); rta = RTA_NEXT(rta, attrLen)) {
+                            if (rta->rta_type == NDA_DST)    dstAddr = RTA_DATA(rta);
+                            if (rta->rta_type == NDA_LLADDR) {
+                                macAddr = static_cast<unsigned char*>(RTA_DATA(rta));
+                                macLen = RTA_PAYLOAD(rta);
+                            }
+                        }
+                        if (!macAddr || macLen < 6) continue;
+
+                        // Log ALL neighbor entries for debugging
+                        QString mac = QString("%1:%2:%3:%4:%5:%6")
+                            .arg(macAddr[0], 2, 16, QChar('0')).arg(macAddr[1], 2, 16, QChar('0'))
+                            .arg(macAddr[2], 2, 16, QChar('0')).arg(macAddr[3], 2, 16, QChar('0'))
+                            .arg(macAddr[4], 2, 16, QChar('0')).arg(macAddr[5], 2, 16, QChar('0'));
+                        char ifnBuf[IF_NAMESIZE] = {};
+                        QString ifn = if_indextoname(ndm->ndm_ifindex, ifnBuf)
+                            ? QString::fromLatin1(ifnBuf) : QString::number(ndm->ndm_ifindex);
+
+                        char ipBuf[INET6_ADDRSTRLEN] = {};
+                        if (dstAddr) {
+                            if (ndm->ndm_family == AF_INET6)
+                                inet_ntop(AF_INET6, dstAddr, ipBuf, sizeof(ipBuf));
+                            else if (ndm->ndm_family == AF_INET)
+                                inet_ntop(AF_INET, dstAddr, ipBuf, sizeof(ipBuf));
+                        }
+                        qInfo() << "RajantDiscovery: neigh" << ipBuf << "MAC:" << mac
+                            << "iface:" << ifn << "family:" << ndm->ndm_family;
+
+                        // Check for Rajant OUI
+                        bool isRajant = ((macAddr[0] == 0x84 || macAddr[0] == 0x86) &&
+                            macAddr[1] == 0x8D && macAddr[2] == 0x84);
+                        if (!isRajant) continue;
+
+                        if (ndm->ndm_family == AF_INET6 && dstAddr) {
+                            QString addr6 = QString("%1%%%2").arg(ipBuf, ifn);
+                            if (!_rajantCandidates.contains(addr6)) {
+                                _rajantCandidates.append(addr6);
+                                qInfo() << "RajantDiscovery: RAJANT IPv6:" << addr6;
+                            }
+                        }
+                        else if (ndm->ndm_family == AF_INET && dstAddr) {
+                            // Construct fe80:: EUI-64 from MAC
+                            unsigned char eui[16] = { 0xfe,0x80,0,0,0,0,0,0,0,0,0,0,0,0,0,0 };
+                            eui[8] = macAddr[0] ^ 0x02;
+                            eui[9] = macAddr[1]; eui[10] = macAddr[2];
+                            eui[11] = 0xFF; eui[12] = 0xFE;
+                            eui[13] = macAddr[3]; eui[14] = macAddr[4]; eui[15] = macAddr[5];
+                            char euiBuf[INET6_ADDRSTRLEN];
+                            inet_ntop(AF_INET6, eui, euiBuf, sizeof(euiBuf));
+                            // Try all IPv6 scope IDs we can find
+                            for (const auto& iface : interfaces) {
+                                if (!(iface.flags() & QNetworkInterface::IsUp)) continue;
+                                if (iface.flags() & QNetworkInterface::IsLoopBack) continue;
+                                // Only use interfaces that have the same index or have fe80::
+                                for (const auto& entry : iface.addressEntries()) {
+                                    if (entry.ip().protocol() == QAbstractSocket::IPv6Protocol &&
+                                        entry.ip().toString().startsWith("fe80", Qt::CaseInsensitive)) {
+                                        QString sid = entry.ip().scopeId();
+                                        if (sid.isEmpty()) sid = iface.name();
+                                        QString addr6 = QString("%1%%%2").arg(euiBuf, sid);
+                                        if (!_rajantCandidates.contains(addr6)) {
+                                            _rajantCandidates.append(addr6);
+                                            qInfo() << "RajantDiscovery: RAJANT ARP->IPv6:" << addr6
+                                                << "(from" << ipBuf << "MAC:" << mac << ")";
+                                        }
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            else {
+                qWarning() << "RajantDiscovery: netlink send failed:" << strerror(errno);
+            }
+            ::close(nlSock);
+        }
+        else {
+            qWarning() << "RajantDiscovery: netlink socket failed:" << strerror(errno);
+        }
+    }
+
+    if (_rajantCandidates.isEmpty()) {
+        qWarning() << "RajantDiscovery: no Rajant nodes found. Retrying in 10s...";
+        QTimer::singleShot(10000, this, &CustomPlugin::_initRajantDiscovery);
+        return;
+    }
+
+    qInfo() << "RajantDiscovery: probing" << _rajantCandidates.size() << "candidates via TCP:2300...";
+    _tryNextRajantCandidate();
+
+#else
+    // Desktop: Query IPv6 neighbor table via system command
+    QProcess* process = new QProcess(this);
+    connect(process, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),
+        this, &CustomPlugin::_onRajantScanFinished);
+
+#if defined(Q_OS_WIN)
+    // Windows: netsh interface ipv6 show neighbors
+    process->start("netsh", QStringList() << "interface" << "ipv6" << "show" << "neighbors");
+#else
+    // Linux: ip -6 neigh show
+    process->start("ip", QStringList() << "-6" << "neigh" << "show");
+#endif
+
+#endif // Q_OS_ANDROID
+}
+
+void CustomPlugin::_onRajantScanFinished(int exitCode, QProcess::ExitStatus exitStatus)
+{
+    QProcess* process = qobject_cast<QProcess*>(sender());
+    if (!process) return;
+
+    QString output = QString::fromLocal8Bit(process->readAllStandardOutput());
+    process->deleteLater();
+
+    if (exitCode != 0 || exitStatus != QProcess::NormalExit) {
+        qWarning() << "RajantDiscovery: neighbor scan failed, exit code:" << exitCode;
+        // Retry after 10 seconds
+        QTimer::singleShot(10000, this, &CustomPlugin::_initRajantDiscovery);
+        return;
+    }
+
+    // Parse the output for fe80:: addresses with Rajant MAC OUI
+    // Rajant OUI: 84-8D-84 or 86-8D-84 (Windows format with dashes)
+    //             84:8d:84 or 86:8d:84 (Linux format with colons)
+    _rajantCandidates.clear();
+
+    const QStringList lines = output.split('\n');
+    for (const QString& line : lines) {
+        QString trimmed = line.trimmed();
+        if (!trimmed.contains("fe80", Qt::CaseInsensitive)) continue;
+
+        // Check for Rajant MAC OUI
+        bool isRajant = trimmed.contains("84-8d-84", Qt::CaseInsensitive) ||
+            trimmed.contains("86-8d-84", Qt::CaseInsensitive) ||
+            trimmed.contains("84:8d:84", Qt::CaseInsensitive) ||
+            trimmed.contains("86:8d:84", Qt::CaseInsensitive);
+        if (!isRajant) continue;
+
+        // Check it's reachable (not "Unreachable")
+        if (trimmed.contains("Unreachable", Qt::CaseInsensitive)) continue;
+
+        // Extract the fe80:: address
+        // Windows format: "fe80::848d:84ff:fe42:bc30     86-8d-84-42-bc-30  Reachable"
+        // Linux format:   "fe80::848d:84ff:fe42:bc30 dev eth0 lladdr 86:8d:84:42:bc:30 REACHABLE"
+        QStringList parts = trimmed.split(QRegExp("\\s+"));
+        if (parts.isEmpty()) continue;
+
+        QString ipv6Addr = parts.first();
+        if (!ipv6Addr.startsWith("fe80", Qt::CaseInsensitive)) continue;
+
+        // On Windows, we need to find the interface index for scoping
+        // The address from netsh doesn't include the scope, we need to add it
+        // We'll try connecting without scope first, then with detected interfaces
+        _rajantCandidates.append(ipv6Addr);
+        qInfo() << "RajantDiscovery: found Rajant node candidate:" << ipv6Addr
+            << "MAC:" << (parts.size() > 1 ? parts.at(1) : "unknown");
+    }
+
+    if (_rajantCandidates.isEmpty()) {
+        qInfo() << "RajantDiscovery: no Rajant nodes found on network."
+            << "Make sure a Rajant node is connected via Ethernet.";
+
+        // Retry discovery after 10 seconds
+        QTimer::singleShot(10000, this, &CustomPlugin::_initRajantDiscovery);
+        return;
+    }
+
+    // For Windows, we need to add the scope ID (interface index) to each candidate
+    // Find all interfaces with fe80:: addresses and try each combination
+#if defined(Q_OS_WIN)
+    QStringList scopedCandidates;
+    const auto interfaces = QNetworkInterface::allInterfaces();
+    for (const auto& iface : interfaces) {
+        if (!(iface.flags() & QNetworkInterface::IsUp)) continue;
+        if (iface.flags() & QNetworkInterface::IsLoopBack) continue;
+
+        for (const auto& entry : iface.addressEntries()) {
+            QHostAddress addr = entry.ip();
+            if (addr.protocol() == QAbstractSocket::IPv6Protocol &&
+                addr.toString().startsWith("fe80", Qt::CaseInsensitive)) {
+                // Get the scope ID from our own address
+                QString scopeId = addr.scopeId();
+                if (scopeId.isEmpty()) continue;
+
+                for (const QString& candidate : _rajantCandidates) {
+                    QString scoped = candidate + "%" + scopeId;
+                    scopedCandidates.append(scoped);
+                }
+            }
+        }
+    }
+    _rajantCandidates = scopedCandidates;
+#endif
+
+    qInfo() << "RajantDiscovery: probing" << _rajantCandidates.size() << "candidates via TCP:2300...";
+
+    // Try connecting to each candidate
+    _tryNextRajantCandidate();
+}
+
+void CustomPlugin::_tryNextRajantCandidate()
+{
+    if (_rajantCandidates.isEmpty()) {
+        qInfo() << "RajantDiscovery: no candidates responded on TCP:2300."
+            << "Retrying in 10 seconds...";
+        QTimer::singleShot(10000, this, &CustomPlugin::_initRajantDiscovery);
+        return;
+    }
+
+    QString candidate = _rajantCandidates.takeFirst();
+    qInfo() << "RajantDiscovery: probing" << candidate << "...";
+
+    // Clean up previous probe socket
+    if (_rajantProbeSocket) {
+        _rajantProbeSocket->disconnect();
+        _rajantProbeSocket->deleteLater();
+    }
+
+    _rajantProbeSocket = new QTcpSocket(this);
+    _rajantProbeSocket->setProperty("address", candidate);
+
+    connect(_rajantProbeSocket, &QTcpSocket::connected,
+        this, &CustomPlugin::_onRajantProbeConnected);
+    connect(_rajantProbeSocket, &QAbstractSocket::errorOccurred,
+        this, &CustomPlugin::_onRajantProbeError);
+
+    // 3 second timeout per candidate
+    QTimer::singleShot(3000, this, [this, candidate]() {
+        if (_rajantProbeSocket && _rajantProbeSocket->state() != QAbstractSocket::ConnectedState &&
+            _rajantProbeSocket->property("address").toString() == candidate) {
+            qInfo() << "RajantDiscovery: timeout probing" << candidate;
+            _rajantProbeSocket->abort();
+            _tryNextRajantCandidate();
+        }
+        });
+
+    QHostAddress hostAddr(candidate);
+    _rajantProbeSocket->connectToHost(hostAddr, 2300);
+}
+
+void CustomPlugin::_onRajantProbeConnected()
+{
+    QString address = _rajantProbeSocket->property("address").toString();
+    qInfo() << "RajantDiscovery: TCP:2300 responded on" << address
+        << "- connecting to identify node type...";
+
+    // Clean up probe socket
+    _rajantProbeSocket->disconnect();
+    _rajantProbeSocket->close();
+    _rajantProbeSocket->deleteLater();
+    _rajantProbeSocket = nullptr;
+
+    // The first node to respond is the directly-connected ground unit.
+    // Ground unit's Peer.signal = signal ground receives from air (drone).
+    // This is the RSSI value the pilot needs on the GCS toolbar.
+    _rajantManager = new RajantManager(address, _rajantPassword, this);
+    _rajantCandidates.clear();
+    emit rajantManagerChanged();
+
+    connect(_rajantManager, &RajantManager::firstStateReceived, this,
+        [address](int radioCount) {
+            qInfo() << "";
+            qInfo() << "=== Rajant Discovery Complete ===";
+            qInfo() << "  Ground unit:" << address;
+            qInfo() << "  Radios:     " << radioCount;
+            qInfo() << "  Displaying:  RSSI (ground <- air)";
+            qInfo() << "";
+        });
+}
+
+void CustomPlugin::_onRajantProbeError(QAbstractSocket::SocketError error)
+{
+    Q_UNUSED(error);
+    QString address = _rajantProbeSocket->property("address").toString();
+    qInfo() << "RajantDiscovery: probe failed on" << address << "-" << _rajantProbeSocket->errorString();
+    _tryNextRajantCandidate();
+}
+
 void CustomPlugin::showMessage(const QString& message, SystemMessage::SystemMessageType type)
 {
     qInfo() << "Show Message : "<< message;

--- a/custom/src/CustomPlugin.h
+++ b/custom/src/CustomPlugin.h
@@ -113,15 +113,12 @@ public:
 
     Q_PROPERTY(RajantManager* rajantManager           READ rajantManager          NOTIFY rajantManagerChanged)
     RajantManager* rajantManager() { return _rajantManager; }
-    Q_PROPERTY(RajantManager* rajantAirManager        READ rajantAirManager       NOTIFY rajantAirManagerChanged)
-    RajantManager* rajantAirManager() { return _rajantAirManager; }
 
 signals:
     void rcChannelValuesChanged(const quint16* channels, int count);
     void slaveModeChanged(bool slaveMode);
     void m2ManagerChanged               ();
     void rajantManagerChanged           ();
-    void rajantAirManagerChanged        ();
 
 public slots:
     void showMessage(const QString& message, SystemMessage::SystemMessageType type = SystemMessage::Info);
@@ -142,10 +139,8 @@ private:
 
     QUdpSocket*             _m2boardcastSocket      = nullptr;
     M2Manager*              _m2Manager              = nullptr;
-    RajantManager*          _rajantManager          = nullptr;
-    RajantManager*          _rajantAirManager       = nullptr;
+    RajantManager* _rajantManager = nullptr;
     QStringList             _rajantCandidates;
-    QStringList             _allRajantCandidates;
     QTcpSocket* _rajantProbeSocket = nullptr;
     QString                 _rajantPassword = "breadcrumb-admin";
     int                     _rajantDiscoveryRetries = 0;

--- a/custom/src/CustomPlugin.h
+++ b/custom/src/CustomPlugin.h
@@ -22,8 +22,11 @@
 #include "codevsettings.h"
 
 #include "QGroundControlQmlGlobal.h"
+#include <QProcess>
+#include <QTcpSocket>
 
 #include "M2Manager.h"
+#include "RajantManager.h"
 
 class CustomOptions;
 class CustomPlugin;
@@ -108,10 +111,14 @@ public:
     Q_PROPERTY(M2Manager*           m2Manager               READ m2Manager              NOTIFY m2ManagerChanged)
     M2Manager*              m2Manager           ()  { return _m2Manager; }
 
+    Q_PROPERTY(RajantManager* rajantManager           READ rajantManager          NOTIFY rajantManagerChanged)
+    RajantManager* rajantManager() { return _rajantManager; }
+
 signals:
     void rcChannelValuesChanged(const quint16* channels, int count);
     void slaveModeChanged(bool slaveMode);
     void m2ManagerChanged               ();
+    void rajantManagerChanged           ();
 
 public slots:
     void showMessage(const QString& message, SystemMessage::SystemMessageType type = SystemMessage::Info);
@@ -123,10 +130,20 @@ private slots:
 
 private:
     void _addSettingsEntry(const QString& title, const char* qmlFile, const char* iconFile = nullptr);
+    void _initRajantDiscovery();
+    void _onRajantScanFinished(int exitCode, QProcess::ExitStatus exitStatus);
+    void _tryNextRajantCandidate();
+    void _onRajantProbeConnected();
+    void _onRajantProbeError(QAbstractSocket::SocketError error); 
     QGroundControlQmlGlobal* qGroundControlQmlGlobal;
 
     QUdpSocket*             _m2boardcastSocket      = nullptr;
     M2Manager*              _m2Manager              = nullptr;
+    RajantManager* _rajantManager = nullptr;
+    QStringList             _rajantCandidates;
+    QTcpSocket* _rajantProbeSocket = nullptr;
+    QString                 _rajantPassword = "breadcrumb-admin";
+    int                     _rajantDiscoveryRetries = 0;
 
 private:
     SiYiManager* _siyiManager = nullptr;

--- a/custom/src/CustomPlugin.h
+++ b/custom/src/CustomPlugin.h
@@ -113,12 +113,15 @@ public:
 
     Q_PROPERTY(RajantManager* rajantManager           READ rajantManager          NOTIFY rajantManagerChanged)
     RajantManager* rajantManager() { return _rajantManager; }
+    Q_PROPERTY(RajantManager* rajantAirManager        READ rajantAirManager       NOTIFY rajantAirManagerChanged)
+    RajantManager* rajantAirManager() { return _rajantAirManager; }
 
 signals:
     void rcChannelValuesChanged(const quint16* channels, int count);
     void slaveModeChanged(bool slaveMode);
     void m2ManagerChanged               ();
     void rajantManagerChanged           ();
+    void rajantAirManagerChanged        ();
 
 public slots:
     void showMessage(const QString& message, SystemMessage::SystemMessageType type = SystemMessage::Info);
@@ -139,8 +142,10 @@ private:
 
     QUdpSocket*             _m2boardcastSocket      = nullptr;
     M2Manager*              _m2Manager              = nullptr;
-    RajantManager* _rajantManager = nullptr;
+    RajantManager*          _rajantManager          = nullptr;
+    RajantManager*          _rajantAirManager       = nullptr;
     QStringList             _rajantCandidates;
+    QStringList             _allRajantCandidates;
     QTcpSocket* _rajantProbeSocket = nullptr;
     QString                 _rajantPassword = "breadcrumb-admin";
     int                     _rajantDiscoveryRetries = 0;

--- a/custom/src/CustomPlugin.h
+++ b/custom/src/CustomPlugin.h
@@ -134,7 +134,11 @@ private:
     void _onRajantScanFinished(int exitCode, QProcess::ExitStatus exitStatus);
     void _tryNextRajantCandidate();
     void _onRajantProbeConnected();
-    void _onRajantProbeError(QAbstractSocket::SocketError error); 
+    void _onRajantProbeError(QAbstractSocket::SocketError error);
+    // Returns the name of an active non-Rajant link, or empty if none.
+    // Used to pre-empt Rajant discovery / probing whenever Enpulse M1, M2 or
+    // DoodleLab are already running — Rajant should never compete for the link.
+    QString _activeNonRajantLinkName() const;
     QGroundControlQmlGlobal* qGroundControlQmlGlobal;
 
     QUdpSocket*             _m2boardcastSocket      = nullptr;

--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -452,6 +452,7 @@ INCLUDEPATH += \
     src/ui/toolbar \
     src/ui/uas \
 	src/M2Link \
+    src/RajantLink \
 
 contains (DEFINES, QGC_ENABLE_PAIRING) {
     INCLUDEPATH += \
@@ -803,6 +804,8 @@ HEADERS += \
     src/AnalyzeView/GeoTagController.h \
     src/AnalyzeView/ExifParser.h \
     src/M2Link/M2Manager.h \
+    src/RajantLink/BcapiProtocol.h \
+    src/RajantLink/RajantManager.h \
     src/Camera/TargetObject.h \
     src/Camera/CodevCameraControl.h \
 
@@ -1073,6 +1076,7 @@ SOURCES += \
     src/AnalyzeView/GeoTagController.cc \
     src/AnalyzeView/ExifParser.cc \
     src/M2Link/M2Manager.cpp \
+    src/RajantLink/RajantManager.cpp \
     src/Camera/TargetObject.cpp \
     src/Camera/CodevCameraControl.cc \
 

--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -20,6 +20,7 @@
         <file alias="APMSupportForwardingIndicator.qml">src/ui/toolbar/APMSupportForwardingIndicator.qml</file>
         <file alias="GimbalIndicator.qml">src/ui/toolbar/GimbalIndicator.qml</file>
         <file alias="M2LinkIndicator.qml">src/M2Link/M2LinkIndicator.qml</file>
+		<file alias="RajantLinkIndicator.qml">src/RajantLink/RajantLinkIndicator.qml</file>
 		<file alias="MainToolBar.qml">src/ui/toolbar/MainToolBar.qml</file>
     </qresource>
     <qresource prefix="/checklists">
@@ -33,6 +34,7 @@
     <qresource prefix="/qml">
 		<file alias="CodevCameraVisual.qml">src/Camera/CodevCameraVisual.qml</file>
 		<file alias="M2Settings.qml">src/M2Link/M2Settings.qml</file>
+		<file alias="RajantSettings.qml">src/RajantLink/RajantSettings.qml</file>
 		<!--<file alias="QGCBusyIndicator.qml">src/QmlControls/QGCBusyIndicator.qml</file> -->
 		<file alias="QGroundControl/Controls/PseudocolorBar.qml">src/QmlControls/PseudocolorBar.qml</file>
 		<file alias="QGroundControl/Controls/TouchSelectArea.qml">src/QmlControls/TouchSelectArea.qml</file>

--- a/src/M2Link/M2Manager.cpp
+++ b/src/M2Link/M2Manager.cpp
@@ -214,6 +214,13 @@ void M2Manager::_handle_scan(const QByteArray& message)
 
 void M2Manager::_pollInfo()
 {
+    if (!_mounted && !_connected) {
+        // Don't poll if we've never successfully connected
+        // This prevents QIODevice::read spam when no M2 device is present
+        static int skipCount = 0;
+        if (++skipCount < 10) return; // only try every 10th poll (10 seconds)
+        skipCount = 0;
+    }
     QUrl url(QString("http://%1:%2/wifi_info").arg(_deviceIP).arg(_port));
     QNetworkRequest request(url);
     request.setTransferTimeout(400);

--- a/src/RajantLink/BcapiProtocol.h
+++ b/src/RajantLink/BcapiProtocol.h
@@ -1,0 +1,393 @@
+#pragma once
+
+#include <QByteArray>
+#include <QCryptographicHash>
+#include <QtEndian>
+#include <QDebug>
+
+/**
+ * Minimal BCAPI wire protocol encoder/decoder.
+ *
+ * BCAPI wire format:
+ *   [size: 4 bytes BE] [compression: 1 byte] [reserved: 3 bytes] [protobuf payload]
+ *
+ * Auth handshake:
+ *   1. Server sends BCMessage with auth.challengeOrResponse = nonce
+ *   2. Client sends BCMessage with auth(action=LOGIN, role=ADMIN,
+ *      challengeOrResponse = SHA-384(password + nonce), userAgent="ALESQGC")
+ *   3. Server sends BCMessage with authResult.status = SUCCESS(1)
+ *
+ * State query:
+ *   Client sends BCMessage with empty state + stateFilterPath="wireless"
+ *   Server responds with BCMessage containing State.wireless[] data
+ *
+ * Protobuf field reference:
+ *   BCMessage.ack              = field 1, varint
+ *   BCMessage.sequenceNumber   = field 2, varint (required)
+ *   BCMessage.auth             = field 3, embedded
+ *   BCMessage.state            = field 6, embedded
+ *   BCMessage.authResult       = field 300, embedded
+ *   BCMessage.stateFilterPath  = field 601, string
+ *
+ *   Auth.action                = field 1, varint (LOGIN=0)
+ *   Auth.challengeOrResponse   = field 3, bytes
+ *   Auth.userAgent             = field 4, string
+ *   Auth.role                  = field 8, varint (ADMIN=2)
+ *
+ *   Result.status              = field 1, varint (FAILURE=0, SUCCESS=1)
+ *
+ *   State.wireless             = field 40, repeated embedded
+ *   Wireless.name              = field 4, string
+ *   Wireless.noise             = field 5, int32
+ *   Wireless.channel           = field 6, uint32
+ *   Wireless.txpower           = field 10, int32
+ *   Wireless.peer              = field 16, repeated embedded
+ *   Peer.rate                  = field 5, int32
+ *   Peer.rssi                  = field 6, int32  (SNR)
+ *   Peer.signal                = field 7, int32
+ *   Peer.enabled               = field 3, bool
+ *   Peer.ipv4Address           = field 11, string
+ *   Peer.linkLocalAddress      = field 14, string
+ */
+
+namespace BcapiProtocol {
+
+// --- Protobuf wire types ---
+enum WireType { VARINT = 0, FIXED64 = 1, LENGTH_DELIMITED = 2, FIXED32 = 5 };
+
+// --- Varint encode/decode ---
+
+inline QByteArray encodeVarint(quint64 value)
+{
+    QByteArray result;
+    while (value > 0x7F) {
+        result.append(static_cast<char>((value & 0x7F) | 0x80));
+        value >>= 7;
+    }
+    result.append(static_cast<char>(value & 0x7F));
+    return result;
+}
+
+inline quint64 decodeVarint(const QByteArray& data, int& pos)
+{
+    quint64 result = 0;
+    int shift = 0;
+    while (pos < data.size()) {
+        quint8 byte = static_cast<quint8>(data.at(pos++));
+        result |= static_cast<quint64>(byte & 0x7F) << shift;
+        if (!(byte & 0x80)) break;
+        shift += 7;
+        if (shift >= 64) break;
+    }
+    return result;
+}
+
+// Decode int32 from varint (handles negative values which are sign-extended to 64 bits)
+inline qint32 decodeVarintInt32(const QByteArray& data, int& pos)
+{
+    return static_cast<qint32>(decodeVarint(data, pos));
+}
+
+// --- Tag helpers ---
+
+inline QByteArray encodeTag(int fieldNumber, WireType wireType)
+{
+    return encodeVarint(static_cast<quint64>((fieldNumber << 3) | wireType));
+}
+
+struct Tag {
+    int fieldNumber;
+    WireType wireType;
+};
+
+inline Tag decodeTag(const QByteArray& data, int& pos)
+{
+    quint64 v = decodeVarint(data, pos);
+    return { static_cast<int>(v >> 3), static_cast<WireType>(v & 0x07) };
+}
+
+// --- Field encoders ---
+
+inline QByteArray encodeVarintField(int fieldNumber, quint64 value)
+{
+    return encodeTag(fieldNumber, VARINT) + encodeVarint(value);
+}
+
+inline QByteArray encodeBytesField(int fieldNumber, const QByteArray& value)
+{
+    return encodeTag(fieldNumber, LENGTH_DELIMITED) + encodeVarint(value.size()) + value;
+}
+
+inline QByteArray encodeStringField(int fieldNumber, const QString& value)
+{
+    return encodeBytesField(fieldNumber, value.toUtf8());
+}
+
+inline QByteArray encodeEmbeddedField(int fieldNumber, const QByteArray& message)
+{
+    return encodeTag(fieldNumber, LENGTH_DELIMITED) + encodeVarint(message.size()) + message;
+}
+
+// --- BCAPI wire frame (8-byte header + protobuf) ---
+
+inline QByteArray frameMessage(const QByteArray& protobuf)
+{
+    QByteArray frame(8, '\0');
+    quint32 size = static_cast<quint32>(protobuf.size());
+    qToBigEndian(size, reinterpret_cast<uchar*>(frame.data()));
+    // compression = 0 (NONE), reserved = 0
+    frame.append(protobuf);
+    return frame;
+}
+
+// --- Auth message builders ---
+
+inline QByteArray buildAuthResponse(const QByteArray& challenge, const QString& password, qint64 seqNum)
+{
+    // SHA-384(password_bytes + challenge_bytes)
+    QCryptographicHash hash(QCryptographicHash::Sha384);
+    hash.addData(password.toUtf8());
+    hash.addData(challenge);
+    QByteArray response = hash.result();
+
+    // Auth message: action=LOGIN(0), role=ADMIN(2), challengeOrResponse=hash, userAgent="ALESQGC"
+    QByteArray auth;
+    auth += encodeVarintField(1, 0);                   // action = LOGIN
+    auth += encodeBytesField(3, response);             // challengeOrResponse
+    auth += encodeStringField(4, "ALESQGC");           // userAgent
+    auth += encodeVarintField(8, 2);                   // role = ADMIN
+
+    // BCMessage: ack=true, sequenceNumber, auth
+    QByteArray msg;
+    msg += encodeVarintField(1, 1);                    // ack = true
+    msg += encodeVarintField(2, static_cast<quint64>(seqNum)); // sequenceNumber
+    msg += encodeEmbeddedField(3, auth);               // auth
+
+    return frameMessage(msg);
+}
+
+inline QByteArray buildStateQuery(qint64 seqNum)
+{
+    // BCMessage: ack=true, sequenceNumber, state={}, stateFilterPath="wireless"
+    QByteArray msg;
+    msg += encodeVarintField(1, 1);                    // ack = true
+    msg += encodeVarintField(2, static_cast<quint64>(seqNum)); // sequenceNumber
+    msg += encodeEmbeddedField(6, QByteArray());       // state = {} (empty = get all)
+    msg += encodeStringField(601, "wireless");         // stateFilterPath
+
+    return frameMessage(msg);
+}
+
+// --- Parsed result structures ---
+
+struct PeerInfo {
+    qint32 signal   = 0;  // received signal strength (dBm)
+    qint32 rssi     = 0;  // SNR (dB)
+    qint32 rate     = 0;  // link rate (in 10s of Mbps)
+    bool   enabled  = false;
+    QString ipv4Address;
+    QString linkLocalAddress;
+};
+
+struct WirelessInfo {
+    QString name;
+    qint32  noise    = 0;   // noise floor (dBm)
+    quint32 channel  = 0;
+    qint32  txpower  = 0;   // dBm
+    QList<PeerInfo> peers;
+};
+
+struct StateResult {
+    QList<WirelessInfo> wireless;
+};
+
+// --- Protobuf field skipper ---
+
+inline void skipField(WireType wireType, const QByteArray& data, int& pos)
+{
+    switch (wireType) {
+    case VARINT:
+        decodeVarint(data, pos);
+        break;
+    case FIXED64:
+        pos += 8;
+        break;
+    case LENGTH_DELIMITED: {
+        int len = static_cast<int>(decodeVarint(data, pos));
+        pos += len;
+        break;
+    }
+    case FIXED32:
+        pos += 4;
+        break;
+    default:
+        break;
+    }
+}
+
+// --- Decoders ---
+
+inline PeerInfo decodePeer(const QByteArray& data, int offset, int len)
+{
+    PeerInfo peer;
+    int pos = offset;
+    int end = offset + len;
+    while (pos < end) {
+        Tag tag = decodeTag(data, pos);
+        switch (tag.fieldNumber) {
+        case 3:  peer.enabled = decodeVarint(data, pos) != 0; break;
+        case 5:  peer.rate = decodeVarintInt32(data, pos); break;
+        case 6:  peer.rssi = decodeVarintInt32(data, pos); break;
+        case 7:  peer.signal = decodeVarintInt32(data, pos); break;
+        case 11: { // ipv4Address (string)
+            int slen = static_cast<int>(decodeVarint(data, pos));
+            peer.ipv4Address = QString::fromUtf8(data.mid(pos, slen));
+            pos += slen;
+            break;
+        }
+        case 14: { // linkLocalAddress (string)
+            int slen = static_cast<int>(decodeVarint(data, pos));
+            peer.linkLocalAddress = QString::fromUtf8(data.mid(pos, slen));
+            pos += slen;
+            break;
+        }
+        default:
+            skipField(tag.wireType, data, pos);
+            break;
+        }
+    }
+    return peer;
+}
+
+inline WirelessInfo decodeWireless(const QByteArray& data, int offset, int len)
+{
+    WirelessInfo w;
+    int pos = offset;
+    int end = offset + len;
+    while (pos < end) {
+        Tag tag = decodeTag(data, pos);
+        switch (tag.fieldNumber) {
+        case 4: { // name (string)
+            int slen = static_cast<int>(decodeVarint(data, pos));
+            w.name = QString::fromUtf8(data.mid(pos, slen));
+            pos += slen;
+            break;
+        }
+        case 5:  w.noise = decodeVarintInt32(data, pos); break;
+        case 6:  w.channel = static_cast<quint32>(decodeVarint(data, pos)); break;
+        case 10: w.txpower = decodeVarintInt32(data, pos); break;
+        case 16: { // peer (embedded, repeated)
+            int plen = static_cast<int>(decodeVarint(data, pos));
+            w.peers.append(decodePeer(data, pos, plen));
+            pos += plen;
+            break;
+        }
+        default:
+            skipField(tag.wireType, data, pos);
+            break;
+        }
+    }
+    return w;
+}
+
+inline StateResult decodeState(const QByteArray& data, int offset, int len)
+{
+    StateResult result;
+    int pos = offset;
+    int end = offset + len;
+    while (pos < end) {
+        Tag tag = decodeTag(data, pos);
+        switch (tag.fieldNumber) {
+        case 40: { // wireless (embedded, repeated)
+            int wlen = static_cast<int>(decodeVarint(data, pos));
+            result.wireless.append(decodeWireless(data, pos, wlen));
+            pos += wlen;
+            break;
+        }
+        default:
+            skipField(tag.wireType, data, pos);
+            break;
+        }
+    }
+    return result;
+}
+
+// --- BCMessage top-level parser ---
+
+struct BcapiMessage {
+    QByteArray authChallenge;     // from auth.challengeOrResponse
+    int        authResultStatus = -1; // -1=no result, 0=FAILURE, 1=SUCCESS
+    StateResult state;
+    bool       hasState = false;
+};
+
+inline BcapiMessage parseBcMessage(const QByteArray& data)
+{
+    BcapiMessage msg;
+    int pos = 0;
+    int end = data.size();
+
+    while (pos < end) {
+        Tag tag = decodeTag(data, pos);
+        switch (tag.fieldNumber) {
+        case 3: { // auth (embedded)
+            int alen = static_cast<int>(decodeVarint(data, pos));
+            int aend = pos + alen;
+            while (pos < aend) {
+                Tag atag = decodeTag(data, pos);
+                if (atag.fieldNumber == 3 && atag.wireType == LENGTH_DELIMITED) {
+                    // challengeOrResponse (bytes)
+                    int clen = static_cast<int>(decodeVarint(data, pos));
+                    msg.authChallenge = data.mid(pos, clen);
+                    pos += clen;
+                } else {
+                    skipField(atag.wireType, data, pos);
+                }
+            }
+            break;
+        }
+        case 300: { // authResult (embedded)
+            int rlen = static_cast<int>(decodeVarint(data, pos));
+            int rend = pos + rlen;
+            while (pos < rend) {
+                Tag rtag = decodeTag(data, pos);
+                if (rtag.fieldNumber == 1) {
+                    msg.authResultStatus = static_cast<int>(decodeVarint(data, pos));
+                } else {
+                    skipField(rtag.wireType, data, pos);
+                }
+            }
+            break;
+        }
+        case 6: { // state (embedded)
+            int slen = static_cast<int>(decodeVarint(data, pos));
+            msg.state = decodeState(data, pos, slen);
+            msg.hasState = true;
+            pos += slen;
+            break;
+        }
+        default:
+            skipField(tag.wireType, data, pos);
+            break;
+        }
+    }
+    return msg;
+}
+
+// --- Frame reader helper ---
+// Returns true if a complete frame is available in buffer, extracts the protobuf payload
+inline bool readFrame(QByteArray& buffer, QByteArray& payload)
+{
+    if (buffer.size() < 8) return false;
+
+    quint32 size = qFromBigEndian<quint32>(reinterpret_cast<const uchar*>(buffer.constData()));
+    int totalFrame = 8 + static_cast<int>(size);
+
+    if (buffer.size() < totalFrame) return false;
+
+    payload = buffer.mid(8, static_cast<int>(size));
+    buffer.remove(0, totalFrame);
+    return true;
+}
+
+} // namespace BcapiProtocol

--- a/src/RajantLink/BcapiProtocol.h
+++ b/src/RajantLink/BcapiProtocol.h
@@ -181,9 +181,10 @@ inline QByteArray buildStateQuery(qint64 seqNum)
 // --- Parsed result structures ---
 
 struct PeerInfo {
-    qint32 signal   = 0;  // received signal strength (dBm)
-    qint32 rssi     = 0;  // SNR (dB)
+    qint32 signal   = 0;  // received signal strength at us, from peer (dBm)
+    qint32 rssi     = 0;  // SNR at us, from peer (dB)
     qint32 rate     = 0;  // link rate (in 10s of Mbps)
+    qint32 peerSnr  = 0;  // peer-reported SNR (dB) - what the far end hears from us
     bool   enabled  = false;
     QString ipv4Address;
     QString linkLocalAddress;
@@ -194,6 +195,8 @@ struct WirelessInfo {
     qint32  noise    = 0;   // noise floor (dBm)
     quint32 channel  = 0;
     qint32  txpower  = 0;   // dBm
+    QString nodeName;        // hostname, e.g. "rajant-115877" (Wireless field 15 -> sub-field 3)
+    QString firmwareVersion; // e.g. "10.4-4019-rajant.115.c0a11264" (Wireless field 34)
     QList<PeerInfo> peers;
 };
 
@@ -251,6 +254,7 @@ inline PeerInfo decodePeer(const QByteArray& data, int offset, int len)
             pos += slen;
             break;
         }
+        case 15: peer.peerSnr = decodeVarintInt32(data, pos); break;
         default:
             skipField(tag.wireType, data, pos);
             break;
@@ -276,10 +280,33 @@ inline WirelessInfo decodeWireless(const QByteArray& data, int offset, int len)
         case 5:  w.noise = decodeVarintInt32(data, pos); break;
         case 6:  w.channel = static_cast<quint32>(decodeVarint(data, pos)); break;
         case 10: w.txpower = decodeVarintInt32(data, pos); break;
+        case 15: { // nodeInfo (embedded) — contains hostname at sub-field 3
+            int nlen = static_cast<int>(decodeVarint(data, pos));
+            int npos = pos;
+            int nend = pos + nlen;
+            while (npos < nend) {
+                Tag ntag = decodeTag(data, npos);
+                if (ntag.fieldNumber == 3 && ntag.wireType == LENGTH_DELIMITED) {
+                    int slen = static_cast<int>(decodeVarint(data, npos));
+                    w.nodeName = QString::fromUtf8(data.mid(npos, slen));
+                    npos += slen;
+                } else {
+                    skipField(ntag.wireType, data, npos);
+                }
+            }
+            pos += nlen;
+            break;
+        }
         case 16: { // peer (embedded, repeated)
             int plen = static_cast<int>(decodeVarint(data, pos));
             w.peers.append(decodePeer(data, pos, plen));
             pos += plen;
+            break;
+        }
+        case 34: { // firmwareVersion (string)
+            int slen = static_cast<int>(decodeVarint(data, pos));
+            w.firmwareVersion = QString::fromUtf8(data.mid(pos, slen));
+            pos += slen;
             break;
         }
         default:

--- a/src/RajantLink/RajantLinkIndicator.qml
+++ b/src/RajantLink/RajantLinkIndicator.qml
@@ -14,16 +14,11 @@ Item {
     QGCPalette { id: qgcPal }
 
     property var  rajantManager:    QGroundControl.corePlugin.rajantManager
-    property var  rajantAirManager: QGroundControl.corePlugin.rajantAirManager
     property bool _connected:       rajantManager ? rajantManager.connected && rajantManager.authenticated : false
-    property bool _airConnected:    rajantAirManager ? rajantAirManager.connected && rajantAirManager.authenticated : false
     property int  _signal:          rajantManager ? rajantManager.signal : 0
     property int  _noise:           rajantManager ? rajantManager.noise  : 0
     property int  _snr:             rajantManager ? rajantManager.snr    : 0
     property int  _linkRate:        rajantManager ? rajantManager.linkRate : 0
-    // Air unit data (air <- ground direction)
-    property int  _airSignal:       rajantAirManager ? rajantAirManager.signal : 0
-    property int  _airNoise:        rajantAirManager ? rajantAirManager.noise  : 0
 
     function getSignalStrength(signal) {
         // Map dBm signal to percentage for signal icon
@@ -69,68 +64,46 @@ Item {
                     columns:                    2
                     anchors.horizontalCenter:   parent.horizontalCenter
 
+                    QGCLabel { text: qsTr("Radio:"); color: qgcPal.text }
+                    QGCLabel {
+                        text: rajantManager ? rajantManager.radioName + " (ch " + rajantManager.channel + ")" : "N/A"
+                        color: qgcPal.text
+                    }
+
                     QGCLabel { text: qsTr("Signal:"); color: qgcPal.text }
                     QGCLabel {
-                        text: _connected ? _signal + " / " + _noise + " dBm" : qsTr("N/A")
+                        text: _connected ? _signal + " dBm" : qsTr("N/A")
                         color: qgcPal.text
                     }
 
-                    QGCLabel { text: qsTr("Sky Signal:"); color: qgcPal.text }
-                    QGCLabel {
-                        text: _airConnected ? _airSignal + " / " + _airNoise + " dBm" : qsTr("N/A")
-                        color: qgcPal.text
-                    }
-
-                    QGCLabel { text: qsTr("Noise:"); color: qgcPal.text; visible: false }
+                    QGCLabel { text: qsTr("Noise:"); color: qgcPal.text }
                     QGCLabel {
                         text: _connected ? _noise + " dBm" : qsTr("N/A")
                         color: qgcPal.text
-                        visible: false
                     }
 
-                    QGCLabel { text: qsTr("Sky Noise:"); color: qgcPal.text; visible: false }
-                    QGCLabel {
-                        text: _airConnected ? _airNoise + " dBm" : qsTr("N/A")
-                        color: qgcPal.text
-                        visible: false
-                    }
-
-                    QGCLabel { text: qsTr("Main Link:"); color: qgcPal.text }
-                    QGCLabel { text: qsTr("UDP"); color: qgcPal.text }
-
-                    QGCLabel { text: qsTr("Radio:"); color: qgcPal.text; visible: false }
-                    QGCLabel {
-                        text: rajantManager ? rajantManager.radioName + " (ch " + rajantManager.channel + ")" : "N/A"
-                        color: qgcPal.text; 
-                        visible: false
-                    }
-
-                    QGCLabel { text: qsTr("SNR:"); color: qgcPal.text; visible: false }
+                    QGCLabel { text: qsTr("SNR:"); color: qgcPal.text }
                     QGCLabel {
                         text: _connected ? _snr + " dB" : qsTr("N/A")
-                        color: qgcPal.text; 
-                        visible: false
+                        color: qgcPal.text
                     }
 
-                    QGCLabel { text: qsTr("Link Rate:"); color: qgcPal.text; visible: false }
+                    QGCLabel { text: qsTr("Link Rate:"); color: qgcPal.text }
                     QGCLabel {
                         text: _connected ? _linkRate + " Mbps" : qsTr("N/A")
-                        color: qgcPal.text; 
-                        visible: false
+                        color: qgcPal.text
                     }
 
-                    QGCLabel { text: qsTr("Tx Power:"); color: qgcPal.text; visible: false }
+                    QGCLabel { text: qsTr("Tx Power:"); color: qgcPal.text }
                     QGCLabel {
                         text: _connected && rajantManager ? rajantManager.txPower + " dBm" : qsTr("N/A")
-                        color: qgcPal.text; 
-                        visible: false
+                        color: qgcPal.text
                     }
 
-                    QGCLabel { text: qsTr("Peers:"); color: qgcPal.text; visible: false }
+                    QGCLabel { text: qsTr("Peers:"); color: qgcPal.text }
                     QGCLabel {
                         text: _connected && rajantManager ? rajantManager.peerCount.toString() : qsTr("N/A")
-                        color: qgcPal.text; 
-                        visible: false
+                        color: qgcPal.text
                     }
                 }
             }

--- a/src/RajantLink/RajantLinkIndicator.qml
+++ b/src/RajantLink/RajantLinkIndicator.qml
@@ -1,0 +1,149 @@
+import QtQuick          2.12
+import QtQuick.Layouts  1.2
+import QtQuick.Controls 2.5
+
+import QGroundControl                     1.0
+import QGroundControl.Controls            1.0
+import QGroundControl.ScreenTools         1.0
+import QGroundControl.Palette             1.0
+
+Item {
+    id:     _root
+    width:  signalRow.width
+
+    QGCPalette { id: qgcPal }
+
+    property var  rajantManager:    QGroundControl.corePlugin.rajantManager
+    property bool _connected:       rajantManager ? rajantManager.connected && rajantManager.authenticated : false
+    property int  _signal:          rajantManager ? rajantManager.signal : 0
+    property int  _noise:           rajantManager ? rajantManager.noise  : 0
+    property int  _snr:             rajantManager ? rajantManager.snr    : 0
+    property int  _linkRate:        rajantManager ? rajantManager.linkRate : 0
+
+    function getSignalStrength(signal) {
+        // Map dBm signal to percentage for signal icon
+        if (signal === 0 || !_connected)  return 0
+        if (signal <= -90) return 10
+        if (signal <= -80) return 30
+        if (signal <= -70) return 50
+        if (signal <= -60) return 70
+        if (signal <= -50) return 85
+        return 100
+    }
+
+    Component {
+        id: rajantRssiInfo
+        Rectangle {
+            width:                  rssiInfoCol.width  + ScreenTools.defaultFontPixelWidth * 4
+            height:                 rssiInfoCol.height + ScreenTools.defaultFontPixelWidth * 4
+            radius:                 ScreenTools.defaultFontPixelHeight * 0.5
+            color:                  qgcPal.window
+            border.color:           qgcPal.text
+
+            MouseArea {
+                anchors.fill:       parent
+                preventStealing:    true
+                onWheel:            wheel.accepted = true
+            }
+
+            Column {
+                id:                             rssiInfoCol
+                spacing:                        ScreenTools.defaultFontPixelHeight
+                anchors.margins:                ScreenTools.defaultFontPixelHeight
+                anchors.centerIn:               parent
+
+                QGCLabel {
+                    text:                       _connected ? qsTr("Rajant Link Status") : qsTr("Rajant Disconnected")
+                    font.family:                ScreenTools.demiboldFontFamily
+                    anchors.horizontalCenter:   parent.horizontalCenter
+                }
+
+                GridLayout {
+                    visible:                    _connected
+                    columnSpacing:              ScreenTools.defaultFontPixelWidth
+                    columns:                    2
+                    anchors.horizontalCenter:   parent.horizontalCenter
+
+                    QGCLabel { text: qsTr("Radio:"); color: qgcPal.text }
+                    QGCLabel {
+                        text: rajantManager ? rajantManager.radioName + " (ch " + rajantManager.channel + ")" : "N/A"
+                        color: qgcPal.text
+                    }
+
+                    QGCLabel { text: qsTr("Signal:"); color: qgcPal.text }
+                    QGCLabel {
+                        text: _connected ? _signal + " dBm" : qsTr("N/A")
+                        color: qgcPal.text
+                    }
+
+                    QGCLabel { text: qsTr("Noise:"); color: qgcPal.text }
+                    QGCLabel {
+                        text: _connected ? _noise + " dBm" : qsTr("N/A")
+                        color: qgcPal.text
+                    }
+
+                    QGCLabel { text: qsTr("SNR:"); color: qgcPal.text }
+                    QGCLabel {
+                        text: _connected ? _snr + " dB" : qsTr("N/A")
+                        color: qgcPal.text
+                    }
+
+                    QGCLabel { text: qsTr("Link Rate:"); color: qgcPal.text }
+                    QGCLabel {
+                        text: _connected ? _linkRate + " Mbps" : qsTr("N/A")
+                        color: qgcPal.text
+                    }
+
+                    QGCLabel { text: qsTr("Tx Power:"); color: qgcPal.text }
+                    QGCLabel {
+                        text: _connected && rajantManager ? rajantManager.txPower + " dBm" : qsTr("N/A")
+                        color: qgcPal.text
+                    }
+
+                    QGCLabel { text: qsTr("Peers:"); color: qgcPal.text }
+                    QGCLabel {
+                        text: _connected && rajantManager ? rajantManager.peerCount.toString() : qsTr("N/A")
+                        color: qgcPal.text
+                    }
+                }
+            }
+        }
+    }
+
+    // Toolbar icon + label
+    Row {
+        id:                     signalRow
+        spacing:                ScreenTools.defaultFontPixelWidth
+        anchors.top:            parent.top
+        anchors.bottom:         parent.bottom
+        anchors.horizontalCenter: parent.horizontalCenter
+
+        SignalStrength {
+            anchors.verticalCenter: parent.verticalCenter
+            size:                   ScreenTools.defaultFontPixelHeight * 1.6
+            percent:                _connected ? getSignalStrength(_signal) : 0
+        }
+        Column {
+            anchors.verticalCenter: parent.verticalCenter
+            spacing: 0
+            QGCLabel {
+                text:               "Rajant"
+                font.pointSize:     ScreenTools.defaultFontPointSize
+            }
+            QGCLabel {
+                text:               _connected ? _signal + " dBm" : "N/A"
+                font.pointSize:     ScreenTools.defaultFontPointSize
+            }
+        }
+    }
+
+    MouseArea {
+        anchors.fill:           parent
+        anchors.margins:        -ScreenTools.defaultFontPixelHeight * 0.66
+        onClicked: {
+            if (_connected) {
+                mainWindow.showIndicatorPopup(_root, rajantRssiInfo)
+            }
+        }
+    }
+}

--- a/src/RajantLink/RajantLinkIndicator.qml
+++ b/src/RajantLink/RajantLinkIndicator.qml
@@ -14,11 +14,14 @@ Item {
     QGCPalette { id: qgcPal }
 
     property var  rajantManager:    QGroundControl.corePlugin.rajantManager
-    property bool _connected:       rajantManager ? rajantManager.connected && rajantManager.authenticated : false
-    property int  _signal:          rajantManager ? rajantManager.signal : 0
-    property int  _noise:           rajantManager ? rajantManager.noise  : 0
-    property int  _snr:             rajantManager ? rajantManager.snr    : 0
-    property int  _linkRate:        rajantManager ? rajantManager.linkRate : 0
+    // Treat a dead mesh link the same as disconnected — UI goes to N/A, not stale values
+    property bool _connected:       rajantManager ? rajantManager.connected && rajantManager.authenticated && rajantManager.linkLive : false
+    property int  _signal:          rajantManager ? rajantManager.signal    : 0
+    property int  _noise:           rajantManager ? rajantManager.noise     : 0
+    property int  _snr:             rajantManager ? rajantManager.snr       : 0
+    property int  _skySignal:       rajantManager ? rajantManager.skySignal : 0
+    property int  _skySnr:          rajantManager ? rajantManager.skySnr    : 0
+    property int  _linkRate:        rajantManager ? rajantManager.linkRate  : 0
 
     function getSignalStrength(signal) {
         // Map dBm signal to percentage for signal icon
@@ -64,15 +67,24 @@ Item {
                     columns:                    2
                     anchors.horizontalCenter:   parent.horizontalCenter
 
-                    QGCLabel { text: qsTr("Radio:"); color: qgcPal.text }
+                    QGCLabel { text: qsTr("Radio:"); color: qgcPal.text; visible:false }
                     QGCLabel {
                         text: rajantManager ? rajantManager.radioName + " (ch " + rajantManager.channel + ")" : "N/A"
                         color: qgcPal.text
+                        visible: false
                     }
 
-                    QGCLabel { text: qsTr("Signal:"); color: qgcPal.text }
+                    QGCLabel { text: qsTr("RSSI:"); color: qgcPal.text }
                     QGCLabel {
-                        text: _connected ? _signal + " dBm" : qsTr("N/A")
+                        text: _connected ? _signal + " dBm / " + _snr + " dB" : qsTr("N/A")
+                        color: qgcPal.text
+                    }
+
+                    QGCLabel { text: qsTr("Sky RSSI:"); color: qgcPal.text }
+                    QGCLabel {
+                        text: _connected && _skySnr > 0
+                              ? _skySignal + " dBm / " + _skySnr + " dB"
+                              : qsTr("N/A")
                         color: qgcPal.text
                     }
 
@@ -82,22 +94,18 @@ Item {
                         color: qgcPal.text
                     }
 
-                    QGCLabel { text: qsTr("SNR:"); color: qgcPal.text }
-                    QGCLabel {
-                        text: _connected ? _snr + " dB" : qsTr("N/A")
-                        color: qgcPal.text
-                    }
-
-                    QGCLabel { text: qsTr("Link Rate:"); color: qgcPal.text }
+                    QGCLabel { text: qsTr("Link Rate:"); color: qgcPal.text; visible: false }
                     QGCLabel {
                         text: _connected ? _linkRate + " Mbps" : qsTr("N/A")
                         color: qgcPal.text
+                        visible: false
                     }
 
-                    QGCLabel { text: qsTr("Tx Power:"); color: qgcPal.text }
+                    QGCLabel { text: qsTr("Tx Power:"); color: qgcPal.text; visible: false }
                     QGCLabel {
                         text: _connected && rajantManager ? rajantManager.txPower + " dBm" : qsTr("N/A")
                         color: qgcPal.text
+                        visible: false
                     }
 
                     QGCLabel { text: qsTr("Peers:"); color: qgcPal.text }
@@ -105,6 +113,8 @@ Item {
                         text: _connected && rajantManager ? rajantManager.peerCount.toString() : qsTr("N/A")
                         color: qgcPal.text
                     }
+                    QGCLabel { text: qsTr("Main Link:"); color: qgcPal.text }
+                    QGCLabel { text: qsTr("UDP"); color: qgcPal.text }
                 }
             }
         }

--- a/src/RajantLink/RajantLinkIndicator.qml
+++ b/src/RajantLink/RajantLinkIndicator.qml
@@ -14,11 +14,16 @@ Item {
     QGCPalette { id: qgcPal }
 
     property var  rajantManager:    QGroundControl.corePlugin.rajantManager
+    property var  rajantAirManager: QGroundControl.corePlugin.rajantAirManager
     property bool _connected:       rajantManager ? rajantManager.connected && rajantManager.authenticated : false
+    property bool _airConnected:    rajantAirManager ? rajantAirManager.connected && rajantAirManager.authenticated : false
     property int  _signal:          rajantManager ? rajantManager.signal : 0
     property int  _noise:           rajantManager ? rajantManager.noise  : 0
     property int  _snr:             rajantManager ? rajantManager.snr    : 0
     property int  _linkRate:        rajantManager ? rajantManager.linkRate : 0
+    // Air unit data (air <- ground direction)
+    property int  _airSignal:       rajantAirManager ? rajantAirManager.signal : 0
+    property int  _airNoise:        rajantAirManager ? rajantAirManager.noise  : 0
 
     function getSignalStrength(signal) {
         // Map dBm signal to percentage for signal icon
@@ -64,46 +69,68 @@ Item {
                     columns:                    2
                     anchors.horizontalCenter:   parent.horizontalCenter
 
-                    QGCLabel { text: qsTr("Radio:"); color: qgcPal.text }
-                    QGCLabel {
-                        text: rajantManager ? rajantManager.radioName + " (ch " + rajantManager.channel + ")" : "N/A"
-                        color: qgcPal.text
-                    }
-
                     QGCLabel { text: qsTr("Signal:"); color: qgcPal.text }
                     QGCLabel {
-                        text: _connected ? _signal + " dBm" : qsTr("N/A")
+                        text: _connected ? _signal + " / " + _noise + " dBm" : qsTr("N/A")
                         color: qgcPal.text
                     }
 
-                    QGCLabel { text: qsTr("Noise:"); color: qgcPal.text }
+                    QGCLabel { text: qsTr("Sky Signal:"); color: qgcPal.text }
+                    QGCLabel {
+                        text: _airConnected ? _airSignal + " / " + _airNoise + " dBm" : qsTr("N/A")
+                        color: qgcPal.text
+                    }
+
+                    QGCLabel { text: qsTr("Noise:"); color: qgcPal.text; visible: false }
                     QGCLabel {
                         text: _connected ? _noise + " dBm" : qsTr("N/A")
                         color: qgcPal.text
+                        visible: false
                     }
 
-                    QGCLabel { text: qsTr("SNR:"); color: qgcPal.text }
+                    QGCLabel { text: qsTr("Sky Noise:"); color: qgcPal.text; visible: false }
+                    QGCLabel {
+                        text: _airConnected ? _airNoise + " dBm" : qsTr("N/A")
+                        color: qgcPal.text
+                        visible: false
+                    }
+
+                    QGCLabel { text: qsTr("Main Link:"); color: qgcPal.text }
+                    QGCLabel { text: qsTr("UDP"); color: qgcPal.text }
+
+                    QGCLabel { text: qsTr("Radio:"); color: qgcPal.text; visible: false }
+                    QGCLabel {
+                        text: rajantManager ? rajantManager.radioName + " (ch " + rajantManager.channel + ")" : "N/A"
+                        color: qgcPal.text; 
+                        visible: false
+                    }
+
+                    QGCLabel { text: qsTr("SNR:"); color: qgcPal.text; visible: false }
                     QGCLabel {
                         text: _connected ? _snr + " dB" : qsTr("N/A")
-                        color: qgcPal.text
+                        color: qgcPal.text; 
+                        visible: false
                     }
 
-                    QGCLabel { text: qsTr("Link Rate:"); color: qgcPal.text }
+                    QGCLabel { text: qsTr("Link Rate:"); color: qgcPal.text; visible: false }
                     QGCLabel {
                         text: _connected ? _linkRate + " Mbps" : qsTr("N/A")
-                        color: qgcPal.text
+                        color: qgcPal.text; 
+                        visible: false
                     }
 
-                    QGCLabel { text: qsTr("Tx Power:"); color: qgcPal.text }
+                    QGCLabel { text: qsTr("Tx Power:"); color: qgcPal.text; visible: false }
                     QGCLabel {
                         text: _connected && rajantManager ? rajantManager.txPower + " dBm" : qsTr("N/A")
-                        color: qgcPal.text
+                        color: qgcPal.text; 
+                        visible: false
                     }
 
-                    QGCLabel { text: qsTr("Peers:"); color: qgcPal.text }
+                    QGCLabel { text: qsTr("Peers:"); color: qgcPal.text; visible: false }
                     QGCLabel {
                         text: _connected && rajantManager ? rajantManager.peerCount.toString() : qsTr("N/A")
-                        color: qgcPal.text
+                        color: qgcPal.text; 
+                        visible: false
                     }
                 }
             }

--- a/src/RajantLink/RajantManager.cpp
+++ b/src/RajantLink/RajantManager.cpp
@@ -92,6 +92,7 @@ void RajantManager::_onSocketEncrypted()
 {
     qInfo() << "RajantManager: SSL handshake complete on" << _nodeAddress;
     _setConnected(true);
+    _reconnectAttempts = 0; // reset on successful connection
     _setStatusText("SSL connected, waiting for auth challenge...");
     _authState = AUTH_WAIT_CHALLENGE;
     // Server will send the BCAPI auth challenge now that SSL is established
@@ -126,9 +127,18 @@ void RajantManager::_reconnectTimer()
 {
     if (_connected) {
         _reconnTimer->stop();
+        _reconnectAttempts = 0;
         return;
     }
-    qInfo() << "RajantManager: attempting reconnect to" << _nodeAddress;
+    if (_reconnectAttempts >= _maxReconnectAttempts) {
+        _reconnTimer->stop();
+        qWarning() << "RajantManager: max reconnect attempts reached, stopping.";
+        _setStatusText("Disconnected - max retries reached");
+        return;
+    }
+    _reconnectAttempts++;
+    qInfo() << "RajantManager: reconnect attempt" << _reconnectAttempts
+        << "of" << _maxReconnectAttempts << "to" << _nodeAddress;
     connectToNode(_nodeAddress);
 }
 

--- a/src/RajantLink/RajantManager.cpp
+++ b/src/RajantLink/RajantManager.cpp
@@ -43,7 +43,7 @@ RajantManager::~RajantManager()
 
 void RajantManager::connectToNode(const QString& address)
 {
-    if (address.isEmpty()) return;
+    if (address.isEmpty() || !_socket) return;
 
     _nodeAddress = address;
     _authState = AUTH_WAIT_CHALLENGE;
@@ -106,7 +106,11 @@ void RajantManager::_onSocketDisconnected()
     _setAuthenticated(false);
     _setStatusText("Disconnected");
 
-    // Auto-reconnect
+    // Air unit: do NOT auto-retry. CustomPlugin kicks reconnect() when the
+    // ground unit sees the peer return. Repeatedly attempting SSL on an
+    // unreachable scoped-IPv6 address destabilizes Qt 5.15.2 on Windows.
+    if (_isAirUnit) return;
+
     if (!_reconnTimer->isActive()) {
         _reconnTimer->start();
     }
@@ -115,8 +119,12 @@ void RajantManager::_onSocketDisconnected()
 void RajantManager::_onSocketError(QAbstractSocket::SocketError error)
 {
     Q_UNUSED(error);
+    if (!_socket) return;
     qWarning() << "RajantManager: socket error:" << _socket->errorString();
     _setStatusText("Error: " + _socket->errorString());
+
+    // Air unit waits for peer-return kick (see _onSocketDisconnected).
+    if (_isAirUnit) return;
 
     if (!_reconnTimer->isActive()) {
         _reconnTimer->start();
@@ -191,8 +199,8 @@ void RajantManager::_processFrame(const QByteArray& payload)
 
         // Report radio count on first State response (used for air unit identification)
         _radioCount = msg.state.wireless.size();
-        if (!_firstStateEmitted) {
-            _firstStateEmitted = true;
+        bool firstState = !_firstStateEmitted;
+        if (firstState) {
 
             // Print full node info like the Java QuickTest output
             qInfo() << "";
@@ -221,8 +229,6 @@ void RajantManager::_processFrame(const QByteArray& payload)
                 }
             }
             qInfo() << "";
-
-            emit firstStateReceived(_radioCount);
         }
 
         for (const auto& w : msg.state.wireless) {
@@ -252,13 +258,20 @@ void RajantManager::_processFrame(const QByteArray& payload)
             }
             break; // use first active radio
         }
+        // Emit firstStateReceived once we have at least one active peer
+        // (CustomPlugin uses this to trigger air-unit connection).
+        if (!_firstStateEmitted && _peerCount > 0) {
+            _firstStateEmitted = true;
+            emit firstStateReceived(_radioCount);
+        }
 
         // Always log current RSSI (every poll)
-        // Ground unit: Peer.signal = signal ground receives from air (drone)
-        qInfo() << QString("[%1] RSSI: %2 / %3 dBm (ground<-air) | SNR: %4 dB | Rate: %5 Mbps | Ch: %6 | Radio: %7")
-                   .arg(_nodeAddress)
-                   .arg(_signal).arg(_noise).arg(_snr)
-                   .arg(_linkRate).arg(_channel).arg(_radioName);
+        QString direction = _isAirUnit ? "air<-ground" : "ground<-air";
+        QString safeAddr = _nodeAddress;
+        safeAddr.replace('%', "%%"); // escape % in IPv6 scope ID so QString::arg doesn't misparse
+        qInfo() << QString("[%1] RSSI: %2 / %3 dBm (%4)")
+            .arg(safeAddr)
+            .arg(_signal).arg(_noise).arg(direction);
 
         if (dataChanged) {
             _setStatusText(QString("RSSI: %1 dBm / Noise: %2 dBm / SNR: %3 dB")

--- a/src/RajantLink/RajantManager.cpp
+++ b/src/RajantLink/RajantManager.cpp
@@ -1,0 +1,294 @@
+#include "RajantManager.h"
+#include <QHostAddress>
+#include <QQmlEngine>
+#include <QSslConfiguration>
+
+RajantManager::RajantManager(const QString& nodeAddress, const QString& password, QObject* parent)
+    : QObject(parent)
+    , _nodeAddress(nodeAddress)
+    , _password(password)
+{
+    QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
+
+    _socket = new QSslSocket(this);
+
+    // Rajant nodes use self-signed certificates — ignore SSL errors
+    connect(_socket, &QSslSocket::encrypted,    this, &RajantManager::_onSocketEncrypted);
+    connect(_socket, &QSslSocket::disconnected, this, &RajantManager::_onSocketDisconnected);
+    connect(_socket, &QSslSocket::readyRead,    this, &RajantManager::_onDataReady);
+    connect(_socket, QOverload<const QList<QSslError>&>::of(&QSslSocket::sslErrors),
+            this, &RajantManager::_onSslErrors);
+    connect(_socket, &QAbstractSocket::errorOccurred,
+            this, &RajantManager::_onSocketError);
+
+    _pollTimer = new QTimer(this);
+    connect(_pollTimer, &QTimer::timeout, this, &RajantManager::_pollState);
+
+    _reconnTimer = new QTimer(this);
+    _reconnTimer->setInterval(_reconnectInterval);
+    connect(_reconnTimer, &QTimer::timeout, this, &RajantManager::_reconnectTimer);
+
+    // Start connection
+    connectToNode(_nodeAddress);
+}
+
+RajantManager::~RajantManager()
+{
+    _pollTimer->stop();
+    _reconnTimer->stop();
+    if (_socket) {
+        _socket->close();
+    }
+}
+
+void RajantManager::connectToNode(const QString& address)
+{
+    if (address.isEmpty()) return;
+
+    _nodeAddress = address;
+    _authState = AUTH_WAIT_CHALLENGE;
+    _recvBuffer.clear();
+    _seqNum = 0;
+    _firstStateEmitted = false;
+
+    _setStatusText("Connecting (SSL) to " + address + "...");
+    qInfo() << "RajantManager: connecting SSL to" << address << "port" << _port;
+
+    // Configure SSL to accept self-signed certs
+    QSslConfiguration sslConfig = QSslConfiguration::defaultConfiguration();
+    sslConfig.setPeerVerifyMode(QSslSocket::VerifyNone);
+    sslConfig.setProtocol(QSsl::AnyProtocol);
+    _socket->setSslConfiguration(sslConfig);
+
+    _socket->connectToHostEncrypted(address, _port);
+}
+
+void RajantManager::disconnect()
+{
+    _pollTimer->stop();
+    _reconnTimer->stop();
+    if (_socket) {
+        _socket->close();
+    }
+    _setConnected(false);
+    _setAuthenticated(false);
+    _setStatusText("Disconnected");
+}
+
+void RajantManager::reconnect()
+{
+    disconnect();
+    connectToNode(_nodeAddress);
+}
+
+void RajantManager::_onSslErrors(const QList<QSslError>& errors)
+{
+    // Rajant nodes use self-signed certificates — this is expected
+    qInfo() << "RajantManager: ignoring SSL errors (self-signed cert):" << errors.size();
+    _socket->ignoreSslErrors();
+}
+
+void RajantManager::_onSocketEncrypted()
+{
+    qInfo() << "RajantManager: SSL handshake complete on" << _nodeAddress;
+    _setConnected(true);
+    _setStatusText("SSL connected, waiting for auth challenge...");
+    _authState = AUTH_WAIT_CHALLENGE;
+    // Server will send the BCAPI auth challenge now that SSL is established
+}
+
+void RajantManager::_onSocketDisconnected()
+{
+    qWarning() << "RajantManager: disconnected from" << _nodeAddress;
+    _pollTimer->stop();
+    _setConnected(false);
+    _setAuthenticated(false);
+    _setStatusText("Disconnected");
+
+    // Auto-reconnect
+    if (!_reconnTimer->isActive()) {
+        _reconnTimer->start();
+    }
+}
+
+void RajantManager::_onSocketError(QAbstractSocket::SocketError error)
+{
+    Q_UNUSED(error);
+    qWarning() << "RajantManager: socket error:" << _socket->errorString();
+    _setStatusText("Error: " + _socket->errorString());
+
+    if (!_reconnTimer->isActive()) {
+        _reconnTimer->start();
+    }
+}
+
+void RajantManager::_reconnectTimer()
+{
+    if (_connected) {
+        _reconnTimer->stop();
+        return;
+    }
+    qInfo() << "RajantManager: attempting reconnect to" << _nodeAddress;
+    connectToNode(_nodeAddress);
+}
+
+void RajantManager::_onDataReady()
+{
+    _recvBuffer.append(_socket->readAll());
+
+    QByteArray payload;
+    while (BcapiProtocol::readFrame(_recvBuffer, payload)) {
+        _processFrame(payload);
+    }
+}
+
+void RajantManager::_processFrame(const QByteArray& payload)
+{
+    BcapiProtocol::BcapiMessage msg = BcapiProtocol::parseBcMessage(payload);
+
+    // Handle auth challenge from server
+    if (!msg.authChallenge.isEmpty() && _authState == AUTH_WAIT_CHALLENGE) {
+        qInfo() << "RajantManager: received auth challenge (" << msg.authChallenge.size() << "bytes), sending SHA-384 response";
+        QByteArray authResp = BcapiProtocol::buildAuthResponse(
+            msg.authChallenge, _password, ++_seqNum);
+        _socket->write(authResp);
+        _socket->flush();
+        _authState = AUTH_WAIT_RESULT;
+        return;
+    }
+
+    // Handle auth result
+    if (msg.authResultStatus >= 0) {
+        if (msg.authResultStatus == 1) { // SUCCESS
+            qInfo() << "RajantManager: authentication successful on" << _nodeAddress;
+            _setAuthenticated(true);
+            _setStatusText("Authenticated - polling RSSI");
+            // Start polling state
+            _pollState(); // immediate first query
+            _pollTimer->start(_pollInterval);
+        } else {
+            qWarning() << "RajantManager: authentication FAILED (status:" << msg.authResultStatus << ")";
+            _setStatusText("Auth failed - check password");
+            _socket->close();
+        }
+        _authState = AUTH_DONE;
+        return;
+    }
+
+    // Handle state response
+    if (msg.hasState) {
+        bool dataChanged = false;
+
+        // Report radio count on first State response (used for air unit identification)
+        _radioCount = msg.state.wireless.size();
+        if (!_firstStateEmitted) {
+            _firstStateEmitted = true;
+
+            // Print full node info like the Java QuickTest output
+            qInfo() << "";
+            qInfo() << "=== Rajant Node:" << _nodeAddress << "===";
+            qInfo() << "  Wireless radios:" << _radioCount;
+
+            for (int i = 0; i < msg.state.wireless.size(); i++) {
+                const auto& w = msg.state.wireless[i];
+                qInfo() << "  Radio" << i << ":";
+                qInfo() << "    Name:   " << w.name;
+                qInfo() << "    Channel:" << w.channel;
+                qInfo() << "    Noise:  " << w.noise << "dBm";
+                qInfo() << "    TxPower:" << w.txpower << "dBm";
+                qInfo() << "    Peers:  " << w.peers.size();
+                for (int j = 0; j < w.peers.size(); j++) {
+                    const auto& p = w.peers[j];
+                    qInfo() << "      Peer" << j << ":";
+                    qInfo() << "        Signal: " << p.signal << "dBm";
+                    qInfo() << "        RSSI:   " << p.rssi << "dB (SNR)";
+                    qInfo() << "        Rate:   " << (p.rate * 10) << "Mbps";
+                    qInfo() << "        Enabled:" << p.enabled;
+                    if (!p.ipv4Address.isEmpty())
+                        qInfo() << "        IPv4:   " << p.ipv4Address;
+                    if (!p.linkLocalAddress.isEmpty())
+                        qInfo() << "        LinkLocal:" << p.linkLocalAddress;
+                }
+            }
+            qInfo() << "";
+
+            emit firstStateReceived(_radioCount);
+        }
+
+        for (const auto& w : msg.state.wireless) {
+            if (w.peers.isEmpty()) continue;
+
+            // Use the first radio that has peers (active link)
+            const auto& peer = w.peers.first();
+
+            int newSignal  = peer.signal;
+            int newNoise   = w.noise;
+            int newSnr     = peer.rssi;
+            int newRate    = peer.rate * 10; // stored as 10s of Mbps
+
+            if (newSignal != _signal || newNoise != _noise || newSnr != _snr ||
+                newRate != _linkRate || w.name != _radioName ||
+                static_cast<int>(w.channel) != _channel || w.txpower != _txPower ||
+                w.peers.size() != _peerCount) {
+                _signal    = newSignal;
+                _noise     = newNoise;
+                _snr       = newSnr;
+                _linkRate  = newRate;
+                _radioName = w.name;
+                _channel   = static_cast<int>(w.channel);
+                _txPower   = w.txpower;
+                _peerCount = w.peers.size();
+                dataChanged = true;
+            }
+            break; // use first active radio
+        }
+
+        // Always log current RSSI (every poll)
+        // Ground unit: Peer.signal = signal ground receives from air (drone)
+        qInfo() << QString("[%1] RSSI: %2 / %3 dBm (ground<-air) | SNR: %4 dB | Rate: %5 Mbps | Ch: %6 | Radio: %7")
+                   .arg(_nodeAddress)
+                   .arg(_signal).arg(_noise).arg(_snr)
+                   .arg(_linkRate).arg(_channel).arg(_radioName);
+
+        if (dataChanged) {
+            _setStatusText(QString("RSSI: %1 dBm / Noise: %2 dBm / SNR: %3 dB")
+                           .arg(_signal).arg(_noise).arg(_snr));
+            emit radioDataChanged();
+        }
+    }
+}
+
+void RajantManager::_pollState()
+{
+    if (!_authenticated || !_socket || _socket->state() != QAbstractSocket::ConnectedState) {
+        return;
+    }
+
+    QByteArray query = BcapiProtocol::buildStateQuery(++_seqNum);
+    _socket->write(query);
+    _socket->flush();
+}
+
+void RajantManager::_setConnected(bool v)
+{
+    if (v != _connected) {
+        _connected = v;
+        emit connectedChanged();
+    }
+}
+
+void RajantManager::_setAuthenticated(bool v)
+{
+    if (v != _authenticated) {
+        _authenticated = v;
+        emit authenticatedChanged();
+    }
+}
+
+void RajantManager::_setStatusText(const QString& text)
+{
+    if (text != _statusText) {
+        _statusText = text;
+        emit statusTextChanged();
+    }
+}

--- a/src/RajantLink/RajantManager.cpp
+++ b/src/RajantLink/RajantManager.cpp
@@ -61,6 +61,9 @@ void RajantManager::connectToNode(const QString& address)
     _socket->setSslConfiguration(sslConfig);
 
     _socket->connectToHostEncrypted(address, _port);
+
+    // Detect silently-dead TCP connections faster (radio unplugged, cable pulled, etc.)
+    _socket->setSocketOption(QAbstractSocket::KeepAliveOption, 1);
 }
 
 void RajantManager::disconnect()
@@ -104,6 +107,16 @@ void RajantManager::_onSocketDisconnected()
     _setConnected(false);
     _setAuthenticated(false);
     _setStatusText("Disconnected");
+
+    // Wipe cached values so UI immediately shows N/A instead of stale numbers
+    _signal = 0; _noise = 0; _snr = 0; _linkRate = 0;
+    _skySignal = 0; _skySnr = 0;
+    _peerCount = 0;
+    _staleCount = 0;
+    _lastPeerChange.invalidate();
+    if (_linkLive) { _linkLive = false; emit linkLiveChanged(); }
+    emit radioDataChanged();
+    emit skyDataChanged();
 
     // Auto-reconnect
     if (!_reconnTimer->isActive()) {
@@ -188,6 +201,18 @@ void RajantManager::_processFrame(const QByteArray& payload)
             qInfo() << "";
             qInfo() << "=== Rajant Node:" << _nodeAddress << "===";
             qInfo() << "  Wireless radios:" << _radioCount;
+            for (const auto& w : msg.state.wireless) {
+                if (!w.nodeName.isEmpty()) {
+                    qInfo() << "  Hostname:       " << w.nodeName;
+                    break;
+                }
+            }
+            for (const auto& w : msg.state.wireless) {
+                if (!w.firmwareVersion.isEmpty()) {
+                    qInfo() << "  Firmware:       " << w.firmwareVersion;
+                    break;
+                }
+            }
 
             for (int i = 0; i < msg.state.wireless.size(); i++) {
                 const auto& w = msg.state.wireless[i];
@@ -200,8 +225,9 @@ void RajantManager::_processFrame(const QByteArray& payload)
                 for (int j = 0; j < w.peers.size(); j++) {
                     const auto& p = w.peers[j];
                     qInfo() << "      Peer" << j << ":";
-                    qInfo() << "        Signal: " << p.signal << "dBm";
-                    qInfo() << "        RSSI:   " << p.rssi << "dB (SNR)";
+                    qInfo() << "        Signal: " << p.signal << "dBm  (ground <- sky)";
+                    qInfo() << "        SNR:    " << p.rssi << "dB    (ground <- sky)";
+                    qInfo() << "        PeerSNR:" << p.peerSnr << "dB    (sky <- ground, reported by sky)";
                     qInfo() << "        Rate:   " << (p.rate * 10) << "Mbps";
                     qInfo() << "        Enabled:" << p.enabled;
                     if (!p.ipv4Address.isEmpty())
@@ -215,6 +241,31 @@ void RajantManager::_processFrame(const QByteArray& payload)
             emit firstStateReceived(_radioCount);
         }
 
+        bool skyChanged = false;
+        bool peerChanged = false;
+
+        // Capture node identity from any radio that reports it
+        for (const auto& w : msg.state.wireless) {
+            if (!w.nodeName.isEmpty() && w.nodeName != _nodeName) {
+                _nodeName = w.nodeName;
+                dataChanged = true;
+            }
+            if (!w.firmwareVersion.isEmpty() && w.firmwareVersion != _firmwareVersion) {
+                _firmwareVersion = w.firmwareVersion;
+                dataChanged = true;
+            }
+        }
+
+        // Is there an enabled peer on any radio? If every peer says enabled=false,
+        // the mesh link is down even if BCAPI/TCP is still up.
+        bool hasEnabledPeer = false;
+        for (const auto& w : msg.state.wireless) {
+            for (const auto& p : w.peers) {
+                if (p.enabled) { hasEnabledPeer = true; break; }
+            }
+            if (hasEnabledPeer) break;
+        }
+
         for (const auto& w : msg.state.wireless) {
             if (w.peers.isEmpty()) continue;
 
@@ -225,6 +276,14 @@ void RajantManager::_processFrame(const QByteArray& payload)
             int newNoise   = w.noise;
             int newSnr     = peer.rssi;
             int newRate    = peer.rate * 10; // stored as 10s of Mbps
+
+            // Sky-side values — derived, no 2nd SSL session needed.
+            //   skySnr    = peer-reported SNR (what the sky radio measures from ground)
+            //   skySignal = skySnr + noise  (estimate: assumes sky noise ~= ground noise)
+            int newSkySnr    = peer.peerSnr;
+            int newSkySignal = (peer.peerSnr > 0 && w.noise < 0)
+                ? (peer.peerSnr + w.noise)
+                : 0;
 
             if (newSignal != _signal || newNoise != _noise || newSnr != _snr ||
                 newRate != _linkRate || w.name != _radioName ||
@@ -239,21 +298,72 @@ void RajantManager::_processFrame(const QByteArray& payload)
                 _txPower   = w.txpower;
                 _peerCount = w.peers.size();
                 dataChanged = true;
+                peerChanged = true;
+            }
+            if (newSkySnr != _skySnr || newSkySignal != _skySignal) {
+                _skySnr    = newSkySnr;
+                _skySignal = newSkySignal;
+                skyChanged = true;
+                peerChanged = true;
             }
             break; // use first active radio
         }
 
-        // Always log current RSSI (every poll)
-        // Ground unit: Peer.signal = signal ground receives from air (drone)
-        qInfo() << QString("[%1] RSSI: %2 / %3 dBm (ground<-air) | SNR: %4 dB | Rate: %5 Mbps | Ch: %6 | Radio: %7")
-                   .arg(_nodeAddress)
-                   .arg(_signal).arg(_noise).arg(_snr)
-                   .arg(_linkRate).arg(_channel).arg(_radioName);
+        // Link-health detection — fixes stale values when the far end is powered off
+        // while the local TCP session is still alive.
+        //   1. peer.enabled == false on every peer → ground knows peer is gone.
+        //   2. 10 consecutive polls (~10s) with no change in any peer value → no RF
+        //      jitter means the ground is just replaying a cached entry.
+        //   3. Wall-clock safety net: _linkDeadTimeoutMs (10s) since last peerChanged,
+        //      regardless of poll count (catches edge cases where the counter
+        //      somehow doesn't advance).
+        if (peerChanged) {
+            _staleCount = 0;
+            _lastPeerChange.restart();
+        } else {
+            _staleCount++;
+        }
+        const bool elapsedOk = _lastPeerChange.isValid()
+            && _lastPeerChange.elapsed() < _linkDeadTimeoutMs;
+        const bool shouldBeLive = hasEnabledPeer && _staleCount < 10 && elapsedOk;
+        if (shouldBeLive != _linkLive) {
+            _linkLive = shouldBeLive;
+            if (!_linkLive) {
+                qWarning() << "RajantManager: link appears dead (hasEnabledPeer="
+                           << hasEnabledPeer << ", staleCount=" << _staleCount
+                           << ", elapsedMs=" << (_lastPeerChange.isValid() ? _lastPeerChange.elapsed() : -1)
+                           << ") — clearing UI values";
+                _signal = 0; _noise = 0; _snr = 0; _linkRate = 0;
+                _skySignal = 0; _skySnr = 0; _peerCount = 0;
+                dataChanged = true;
+                skyChanged = true;
+            } else {
+                qInfo() << "RajantManager: link is live again";
+            }
+            emit linkLiveChanged();
+        }
+
+        // Log RSSI only when the link is live — avoids log spam of stale values
+        // when the remote end has been powered off. staleCount included so we can
+        // verify the stale-detection counter is actually advancing.
+        if (_linkLive) {
+            qInfo() << QString("[%1] Ground: %2 dBm / %3 dB | Sky: %4 dBm / %5 dB | Noise: %6 dBm | Rate: %7 Mbps | Ch: %8 | Radio: %9 | stale=%10")
+                       .arg(_nodeAddress)
+                       .arg(_signal).arg(_snr)
+                       .arg(_skySignal).arg(_skySnr)
+                       .arg(_noise)
+                       .arg(_linkRate).arg(_channel).arg(_radioName)
+                       .arg(_staleCount);
+        }
 
         if (dataChanged) {
-            _setStatusText(QString("RSSI: %1 dBm / Noise: %2 dBm / SNR: %3 dB")
-                           .arg(_signal).arg(_noise).arg(_snr));
+            _setStatusText(QString("Ground: %1 dBm / %2 dB | Sky: %3 dBm / %4 dB")
+                           .arg(_signal).arg(_snr)
+                           .arg(_skySignal).arg(_skySnr));
             emit radioDataChanged();
+        }
+        if (skyChanged) {
+            emit skyDataChanged();
         }
     }
 }

--- a/src/RajantLink/RajantManager.cpp
+++ b/src/RajantLink/RajantManager.cpp
@@ -43,7 +43,7 @@ RajantManager::~RajantManager()
 
 void RajantManager::connectToNode(const QString& address)
 {
-    if (address.isEmpty() || !_socket) return;
+    if (address.isEmpty()) return;
 
     _nodeAddress = address;
     _authState = AUTH_WAIT_CHALLENGE;
@@ -106,11 +106,7 @@ void RajantManager::_onSocketDisconnected()
     _setAuthenticated(false);
     _setStatusText("Disconnected");
 
-    // Air unit: do NOT auto-retry. CustomPlugin kicks reconnect() when the
-    // ground unit sees the peer return. Repeatedly attempting SSL on an
-    // unreachable scoped-IPv6 address destabilizes Qt 5.15.2 on Windows.
-    if (_isAirUnit) return;
-
+    // Auto-reconnect
     if (!_reconnTimer->isActive()) {
         _reconnTimer->start();
     }
@@ -119,12 +115,8 @@ void RajantManager::_onSocketDisconnected()
 void RajantManager::_onSocketError(QAbstractSocket::SocketError error)
 {
     Q_UNUSED(error);
-    if (!_socket) return;
     qWarning() << "RajantManager: socket error:" << _socket->errorString();
     _setStatusText("Error: " + _socket->errorString());
-
-    // Air unit waits for peer-return kick (see _onSocketDisconnected).
-    if (_isAirUnit) return;
 
     if (!_reconnTimer->isActive()) {
         _reconnTimer->start();
@@ -199,8 +191,8 @@ void RajantManager::_processFrame(const QByteArray& payload)
 
         // Report radio count on first State response (used for air unit identification)
         _radioCount = msg.state.wireless.size();
-        bool firstState = !_firstStateEmitted;
-        if (firstState) {
+        if (!_firstStateEmitted) {
+            _firstStateEmitted = true;
 
             // Print full node info like the Java QuickTest output
             qInfo() << "";
@@ -229,6 +221,8 @@ void RajantManager::_processFrame(const QByteArray& payload)
                 }
             }
             qInfo() << "";
+
+            emit firstStateReceived(_radioCount);
         }
 
         for (const auto& w : msg.state.wireless) {
@@ -258,20 +252,13 @@ void RajantManager::_processFrame(const QByteArray& payload)
             }
             break; // use first active radio
         }
-        // Emit firstStateReceived once we have at least one active peer
-        // (CustomPlugin uses this to trigger air-unit connection).
-        if (!_firstStateEmitted && _peerCount > 0) {
-            _firstStateEmitted = true;
-            emit firstStateReceived(_radioCount);
-        }
 
         // Always log current RSSI (every poll)
-        QString direction = _isAirUnit ? "air<-ground" : "ground<-air";
-        QString safeAddr = _nodeAddress;
-        safeAddr.replace('%', "%%"); // escape % in IPv6 scope ID so QString::arg doesn't misparse
-        qInfo() << QString("[%1] RSSI: %2 / %3 dBm (%4)")
-            .arg(safeAddr)
-            .arg(_signal).arg(_noise).arg(direction);
+        // Ground unit: Peer.signal = signal ground receives from air (drone)
+        qInfo() << QString("[%1] RSSI: %2 / %3 dBm (ground<-air) | SNR: %4 dB | Rate: %5 Mbps | Ch: %6 | Radio: %7")
+                   .arg(_nodeAddress)
+                   .arg(_signal).arg(_noise).arg(_snr)
+                   .arg(_linkRate).arg(_channel).arg(_radioName);
 
         if (dataChanged) {
             _setStatusText(QString("RSSI: %1 dBm / Noise: %2 dBm / SNR: %3 dB")

--- a/src/RajantLink/RajantManager.cpp
+++ b/src/RajantLink/RajantManager.cpp
@@ -92,7 +92,6 @@ void RajantManager::_onSocketEncrypted()
 {
     qInfo() << "RajantManager: SSL handshake complete on" << _nodeAddress;
     _setConnected(true);
-    _reconnectAttempts = 0; // reset on successful connection
     _setStatusText("SSL connected, waiting for auth challenge...");
     _authState = AUTH_WAIT_CHALLENGE;
     // Server will send the BCAPI auth challenge now that SSL is established
@@ -127,18 +126,9 @@ void RajantManager::_reconnectTimer()
 {
     if (_connected) {
         _reconnTimer->stop();
-        _reconnectAttempts = 0;
         return;
     }
-    if (_reconnectAttempts >= _maxReconnectAttempts) {
-        _reconnTimer->stop();
-        qWarning() << "RajantManager: max reconnect attempts reached, stopping.";
-        _setStatusText("Disconnected - max retries reached");
-        return;
-    }
-    _reconnectAttempts++;
-    qInfo() << "RajantManager: reconnect attempt" << _reconnectAttempts
-        << "of" << _maxReconnectAttempts << "to" << _nodeAddress;
+    qInfo() << "RajantManager: attempting reconnect to" << _nodeAddress;
     connectToNode(_nodeAddress);
 }
 

--- a/src/RajantLink/RajantManager.h
+++ b/src/RajantLink/RajantManager.h
@@ -1,0 +1,144 @@
+#pragma once
+
+#include <QObject>
+#include <QSslSocket>
+#include <QTimer>
+#include <QUdpSocket>
+#include <QNetworkInterface>
+#include "BcapiProtocol.h"
+
+/**
+ * RajantManager -- connects to a Rajant BreadCrumb node via BCAPI (SSL:2300)
+ * and periodically reads radio signal information (RSSI, noise, SNR).
+ *
+ * Connection:
+ *   SSL/TLS on port 2300 with BCAPI challenge-response auth (SHA-384).
+ *   Rajant nodes use self-signed certificates, so SSL errors are ignored.
+ *
+ * Polling:
+ *   Sends State query with filter "wireless" every _pollInterval ms.
+ *   Parses Wireless.Peer.signal, Wireless.noise, Wireless.Peer.rssi from response.
+ *
+ * Exposed to QML via Q_PROPERTY for RajantLinkIndicator.qml.
+ */
+class RajantManager : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit RajantManager(const QString& nodeAddress, const QString& password, QObject* parent = nullptr);
+    ~RajantManager() override;
+
+    // Connection state
+    Q_PROPERTY(bool     connected       READ connected      NOTIFY connectedChanged)
+    Q_PROPERTY(bool     authenticated   READ authenticated  NOTIFY authenticatedChanged)
+    Q_PROPERTY(QString  nodeAddress     READ nodeAddress     CONSTANT)
+
+    // Air unit radio data (primary display values)
+    Q_PROPERTY(int      signal          READ signal          NOTIFY radioDataChanged)
+    Q_PROPERTY(int      noise           READ noise           NOTIFY radioDataChanged)
+    Q_PROPERTY(int      snr             READ snr             NOTIFY radioDataChanged)
+    Q_PROPERTY(int      linkRate        READ linkRate        NOTIFY radioDataChanged)
+    Q_PROPERTY(QString  radioName       READ radioName       NOTIFY radioDataChanged)
+    Q_PROPERTY(int      channel         READ channel         NOTIFY radioDataChanged)
+    Q_PROPERTY(int      txPower         READ txPower         NOTIFY radioDataChanged)
+    Q_PROPERTY(int      peerCount       READ peerCount       NOTIFY radioDataChanged)
+
+    // Second node data (ground unit, optional)
+    Q_PROPERTY(int      groundSignal    READ groundSignal    NOTIFY groundDataChanged)
+    Q_PROPERTY(int      groundNoise     READ groundNoise     NOTIFY groundDataChanged)
+    Q_PROPERTY(int      groundSnr       READ groundSnr       NOTIFY groundDataChanged)
+
+    // Readable status string
+    Q_PROPERTY(QString  statusText      READ statusText      NOTIFY statusTextChanged)
+
+    bool    connected()     const { return _connected; }
+    bool    authenticated() const { return _authenticated; }
+    QString nodeAddress()   const { return _nodeAddress; }
+
+    int     signal()        const { return _signal; }
+    int     noise()         const { return _noise; }
+    int     snr()           const { return _snr; }
+    int     linkRate()      const { return _linkRate; }
+    QString radioName()     const { return _radioName; }
+    int     channel()       const { return _channel; }
+    int     txPower()       const { return _txPower; }
+    int     peerCount()     const { return _peerCount; }
+
+    int     groundSignal()  const { return _groundSignal; }
+    int     groundNoise()   const { return _groundNoise; }
+    int     groundSnr()     const { return _groundSnr; }
+
+    QString statusText()    const { return _statusText; }
+
+    Q_INVOKABLE void connectToNode(const QString& address);
+    Q_INVOKABLE void disconnect();
+    Q_INVOKABLE void reconnect();
+
+    int radioCount() const { return _radioCount; }
+    QString peerLinkLocalAddress() const { return _peerLinkLocalAddress; }
+
+signals:
+    void connectedChanged();
+    void authenticatedChanged();
+    void radioDataChanged();
+    void groundDataChanged();
+    void statusTextChanged();
+    void firstStateReceived(int radioCount);
+
+private slots:
+    void _onSocketEncrypted();
+    void _onSocketDisconnected();
+    void _onSocketError(QAbstractSocket::SocketError error);
+    void _onSslErrors(const QList<QSslError>& errors);
+    void _onDataReady();
+    void _pollState();
+    void _reconnectTimer();
+
+private:
+    void _processFrame(const QByteArray& payload);
+    void _setConnected(bool v);
+    void _setAuthenticated(bool v);
+    void _setStatusText(const QString& text);
+
+    // Connection
+    QSslSocket*     _socket             = nullptr;
+    QString         _nodeAddress;
+    QString         _password;
+    quint16         _port               = 2300;
+    bool            _connected          = false;
+    bool            _authenticated      = false;
+    QByteArray      _recvBuffer;
+    qint64          _seqNum             = 0;
+
+    // Polling
+    QTimer*         _pollTimer          = nullptr;
+    QTimer*         _reconnTimer        = nullptr;
+    static const int _pollInterval      = 1000;  // ms
+    static const int _reconnectInterval = 5000;  // ms
+
+    bool            _firstStateEmitted  = false;
+    int             _radioCount         = 0;
+    QString         _peerLinkLocalAddress;
+
+    // Air unit radio data
+    int     _signal     = 0;
+    int     _noise      = 0;
+    int     _snr        = 0;
+    int     _linkRate   = 0;
+    QString _radioName;
+    int     _channel    = 0;
+    int     _txPower    = 0;
+    int     _peerCount  = 0;
+
+    // Ground unit radio data (optional second node)
+    int     _groundSignal   = 0;
+    int     _groundNoise    = 0;
+    int     _groundSnr      = 0;
+
+    QString _statusText;
+
+    // Auth state
+    enum AuthState { AUTH_WAIT_CHALLENGE, AUTH_WAIT_RESULT, AUTH_DONE };
+    AuthState _authState = AUTH_WAIT_CHALLENGE;
+};

--- a/src/RajantLink/RajantManager.h
+++ b/src/RajantLink/RajantManager.h
@@ -76,7 +76,7 @@ public:
     Q_INVOKABLE void reconnect();
 
     int radioCount() const { return _radioCount; }
-    void setIsAirUnit(bool isAir) { _isAirUnit = isAir; }
+    QString peerLinkLocalAddress() const { return _peerLinkLocalAddress; }
 
 signals:
     void connectedChanged();
@@ -116,11 +116,12 @@ private:
     QTimer*         _reconnTimer        = nullptr;
     static const int _pollInterval      = 1000;  // ms
     static const int _reconnectInterval = 5000;  // ms
-    static const int _maxReconnectAttempts = 10;  // stop after 10 attempts
+    static const int _maxReconnectAttempts = 5;  // stop after 5 attempts
     int             _reconnectAttempts  = 0;
 
     bool            _firstStateEmitted  = false;
     int             _radioCount         = 0;
+    QString         _peerLinkLocalAddress;
 
     // Air unit radio data
     int     _signal     = 0;
@@ -138,7 +139,6 @@ private:
     int     _groundSnr      = 0;
 
     QString _statusText;
-    bool    _isAirUnit = false;
 
     // Auth state
     enum AuthState { AUTH_WAIT_CHALLENGE, AUTH_WAIT_RESULT, AUTH_DONE };

--- a/src/RajantLink/RajantManager.h
+++ b/src/RajantLink/RajantManager.h
@@ -116,6 +116,8 @@ private:
     QTimer*         _reconnTimer        = nullptr;
     static const int _pollInterval      = 1000;  // ms
     static const int _reconnectInterval = 5000;  // ms
+    static const int _maxReconnectAttempts = 5;  // stop after 5 attempts
+    int             _reconnectAttempts  = 0;
 
     bool            _firstStateEmitted  = false;
     int             _radioCount         = 0;

--- a/src/RajantLink/RajantManager.h
+++ b/src/RajantLink/RajantManager.h
@@ -116,8 +116,6 @@ private:
     QTimer*         _reconnTimer        = nullptr;
     static const int _pollInterval      = 1000;  // ms
     static const int _reconnectInterval = 5000;  // ms
-    static const int _maxReconnectAttempts = 5;  // stop after 5 attempts
-    int             _reconnectAttempts  = 0;
 
     bool            _firstStateEmitted  = false;
     int             _radioCount         = 0;

--- a/src/RajantLink/RajantManager.h
+++ b/src/RajantLink/RajantManager.h
@@ -3,6 +3,7 @@
 #include <QObject>
 #include <QSslSocket>
 #include <QTimer>
+#include <QElapsedTimer>
 #include <QUdpSocket>
 #include <QNetworkInterface>
 #include "BcapiProtocol.h"
@@ -32,9 +33,10 @@ public:
     // Connection state
     Q_PROPERTY(bool     connected       READ connected      NOTIFY connectedChanged)
     Q_PROPERTY(bool     authenticated   READ authenticated  NOTIFY authenticatedChanged)
+    Q_PROPERTY(bool     linkLive        READ linkLive       NOTIFY linkLiveChanged)
     Q_PROPERTY(QString  nodeAddress     READ nodeAddress     CONSTANT)
 
-    // Air unit radio data (primary display values)
+    // Ground-side radio data (what the ground node directly measures)
     Q_PROPERTY(int      signal          READ signal          NOTIFY radioDataChanged)
     Q_PROPERTY(int      noise           READ noise           NOTIFY radioDataChanged)
     Q_PROPERTY(int      snr             READ snr             NOTIFY radioDataChanged)
@@ -44,16 +46,22 @@ public:
     Q_PROPERTY(int      txPower         READ txPower         NOTIFY radioDataChanged)
     Q_PROPERTY(int      peerCount       READ peerCount       NOTIFY radioDataChanged)
 
-    // Second node data (ground unit, optional)
-    Q_PROPERTY(int      groundSignal    READ groundSignal    NOTIFY groundDataChanged)
-    Q_PROPERTY(int      groundNoise     READ groundNoise     NOTIFY groundDataChanged)
-    Q_PROPERTY(int      groundSnr       READ groundSnr       NOTIFY groundDataChanged)
+    // Sky-side radio data (derived from ground session, no 2nd SSL needed):
+    //   skySnr    = peer-reported SNR from Rajant Peer.field15 (measured by sky)
+    //   skySignal = skySnr + noise  (estimated dBm, assumes sky noise ~= ground noise)
+    Q_PROPERTY(int      skySignal       READ skySignal       NOTIFY skyDataChanged)
+    Q_PROPERTY(int      skySnr          READ skySnr          NOTIFY skyDataChanged)
+
+    // Node identity read from the radio State payload
+    Q_PROPERTY(QString  nodeName        READ nodeName        NOTIFY radioDataChanged)
+    Q_PROPERTY(QString  firmwareVersion READ firmwareVersion NOTIFY radioDataChanged)
 
     // Readable status string
     Q_PROPERTY(QString  statusText      READ statusText      NOTIFY statusTextChanged)
 
     bool    connected()     const { return _connected; }
     bool    authenticated() const { return _authenticated; }
+    bool    linkLive()      const { return _linkLive; }
     QString nodeAddress()   const { return _nodeAddress; }
 
     int     signal()        const { return _signal; }
@@ -65,9 +73,11 @@ public:
     int     txPower()       const { return _txPower; }
     int     peerCount()     const { return _peerCount; }
 
-    int     groundSignal()  const { return _groundSignal; }
-    int     groundNoise()   const { return _groundNoise; }
-    int     groundSnr()     const { return _groundSnr; }
+    int     skySignal()     const { return _skySignal; }
+    int     skySnr()        const { return _skySnr; }
+
+    QString nodeName()        const { return _nodeName; }
+    QString firmwareVersion() const { return _firmwareVersion; }
 
     QString statusText()    const { return _statusText; }
 
@@ -81,8 +91,9 @@ public:
 signals:
     void connectedChanged();
     void authenticatedChanged();
+    void linkLiveChanged();
     void radioDataChanged();
-    void groundDataChanged();
+    void skyDataChanged();
     void statusTextChanged();
     void firstStateReceived(int radioCount);
 
@@ -108,6 +119,10 @@ private:
     quint16         _port               = 2300;
     bool            _connected          = false;
     bool            _authenticated      = false;
+    bool            _linkLive           = false;  // true when peer is reachable + data flowing
+    int             _staleCount         = 0;      // consecutive polls with unchanged peer values
+    QElapsedTimer   _lastPeerChange;              // wall-clock: last time peer data actually changed
+    static const int _linkDeadTimeoutMs = 10000;  // 10 s of no peer change → link dead
     QByteArray      _recvBuffer;
     qint64          _seqNum             = 0;
 
@@ -131,10 +146,13 @@ private:
     int     _txPower    = 0;
     int     _peerCount  = 0;
 
-    // Ground unit radio data (optional second node)
-    int     _groundSignal   = 0;
-    int     _groundNoise    = 0;
-    int     _groundSnr      = 0;
+    // Sky-side radio data (derived from peer-reported SNR + ground noise)
+    int     _skySignal      = 0;  // estimated dBm = skySnr + noise
+    int     _skySnr         = 0;  // peer-reported SNR (dB), direct from Peer.field15
+
+    // Node identity (populated from State payload)
+    QString _nodeName;            // hostname, e.g. "rajant-115877"
+    QString _firmwareVersion;     // e.g. "10.4-4019-rajant.115.c0a11264"
 
     QString _statusText;
 

--- a/src/RajantLink/RajantManager.h
+++ b/src/RajantLink/RajantManager.h
@@ -76,7 +76,7 @@ public:
     Q_INVOKABLE void reconnect();
 
     int radioCount() const { return _radioCount; }
-    QString peerLinkLocalAddress() const { return _peerLinkLocalAddress; }
+    void setIsAirUnit(bool isAir) { _isAirUnit = isAir; }
 
 signals:
     void connectedChanged();
@@ -116,12 +116,11 @@ private:
     QTimer*         _reconnTimer        = nullptr;
     static const int _pollInterval      = 1000;  // ms
     static const int _reconnectInterval = 5000;  // ms
-    static const int _maxReconnectAttempts = 5;  // stop after 5 attempts
+    static const int _maxReconnectAttempts = 10;  // stop after 10 attempts
     int             _reconnectAttempts  = 0;
 
     bool            _firstStateEmitted  = false;
     int             _radioCount         = 0;
-    QString         _peerLinkLocalAddress;
 
     // Air unit radio data
     int     _signal     = 0;
@@ -139,6 +138,7 @@ private:
     int     _groundSnr      = 0;
 
     QString _statusText;
+    bool    _isAirUnit = false;
 
     // Auth state
     enum AuthState { AUTH_WAIT_CHALLENGE, AUTH_WAIT_RESULT, AUTH_DONE };

--- a/src/RajantLink/RajantSettings.qml
+++ b/src/RajantLink/RajantSettings.qml
@@ -19,7 +19,9 @@ Rectangle {
     property real _labelWidth:                  _panelWidth * 0.4
     property real _valueWidth:                  _panelWidth * 0.4
     property var rajantManager:                 QGroundControl.corePlugin.rajantManager
+    property var rajantAirManager:              QGroundControl.corePlugin.rajantAirManager
     property bool _connected:                   rajantManager ? rajantManager.connected && rajantManager.authenticated : false
+    property bool _airConnected:                rajantAirManager ? rajantAirManager.connected && rajantAirManager.authenticated : false
 
     readonly property real _internalWidthRatio:          0.8
 
@@ -74,35 +76,55 @@ Rectangle {
                         QGCLabel {
                             text:           qsTr("Node Address:")
                             Layout.minimumWidth: _labelWidth
+                            visible:        false
                         }
                         QGCLabel {
                             text:           rajantManager ? rajantManager.nodeAddress : qsTr("N/A")
                             Layout.minimumWidth: _valueWidth
+                            visible:        false
                         }
                         QGCLabel {
                             text:           qsTr("Radio:")
-                            visible:        _connected
+                            visible:        false
                         }
                         QGCLabel {
                             text:           rajantManager ? rajantManager.radioName + " (ch " + rajantManager.channel + ")" : ""
-                            visible:        _connected
+                            visible:        false
                         }
                         QGCLabel {
                             text:           qsTr("Signal:")
                             visible:        _connected
                         }
                         QGCLabel {
-                            text:           rajantManager ? rajantManager.signal + " dBm" : ""
+                            text:           rajantManager ? rajantManager.signal + " / " + rajantManager.noise + " dBm" : ""
                             visible:        _connected
                         }
                         QGCLabel {
-                            text:           qsTr("Noise Floor:")
+                            text:           qsTr("Noise:")
                             visible:        _connected
                         }
                         QGCLabel {
                             text:           rajantManager ? rajantManager.noise + " dBm" : ""
                             visible:        _connected
                         }
+
+                        QGCLabel {
+                            text:           qsTr("Sky Signal:")
+                            visible:        _airConnected
+                        }
+                        QGCLabel {
+                            text:           rajantAirManager ? rajantAirManager.signal + " / " + rajantAirManager.noise + " dBm" : ""
+                            visible:        _airConnected
+                        }
+                        QGCLabel {
+                            text:           qsTr("Sky Noise:")
+                            visible:        _airConnected
+                        }
+                        QGCLabel {
+                            text:           rajantAirManager ? rajantAirManager.noise + " dBm" : ""
+                            visible:        _airConnected
+                        }
+
                         QGCLabel {
                             text:           qsTr("SNR:")
                             visible:        _connected
@@ -113,11 +135,11 @@ Rectangle {
                         }
                         QGCLabel {
                             text:           qsTr("Link Rate:")
-                            visible:        _connected
+                            visible:        false
                         }
                         QGCLabel {
                             text:           rajantManager ? rajantManager.linkRate + " Mbps" : ""
-                            visible:        _connected
+                            visible:        false
                         }
                         QGCLabel {
                             text:           qsTr("Tx Power:")
@@ -134,6 +156,12 @@ Rectangle {
                         QGCLabel {
                             text:           rajantManager ? rajantManager.peerCount.toString() : ""
                             visible:        _connected
+                        }
+                        QGCLabel {
+                            text:           qsTr("Version:")
+                        }
+                        QGCLabel {
+                            text:           qsTr("Rajant BCAPI 11.29")
                         }
                     }
                 }

--- a/src/RajantLink/RajantSettings.qml
+++ b/src/RajantLink/RajantSettings.qml
@@ -1,0 +1,143 @@
+import QtQuick                  2.3
+import QtQuick.Controls         1.2
+import QtQuick.Controls.Styles  1.4
+import QtQuick.Layouts          1.2
+
+import QGroundControl                       1.0
+import QGroundControl.Controls              1.0
+import QGroundControl.Palette               1.0
+import QGroundControl.ScreenTools           1.0
+import QGroundControl.SettingsManager       1.0
+
+Rectangle {
+    id:                 _root
+    color:              qgcPal.window
+    anchors.fill:       parent
+    anchors.margins:    ScreenTools.defaultFontPixelWidth
+
+    property real _panelWidth:                  _root.width * _internalWidthRatio
+    property real _labelWidth:                  _panelWidth * 0.4
+    property real _valueWidth:                  _panelWidth * 0.4
+    property var rajantManager:                 QGroundControl.corePlugin.rajantManager
+    property bool _connected:                   rajantManager ? rajantManager.connected && rajantManager.authenticated : false
+
+    readonly property real _internalWidthRatio:          0.8
+
+    QGCFlickable {
+        clip:               true
+        anchors.fill:       parent
+        contentHeight:      settingsColumn.height
+        contentWidth:       settingsColumn.width
+        Column {
+            id:                 settingsColumn
+            width:              _root.width
+            spacing:            ScreenTools.defaultFontPixelHeight * 0.5
+            anchors.margins:    ScreenTools.defaultFontPixelWidth
+            //-----------------------------------------------------------------
+            //-- Link Status
+            Item {
+                width:                      _panelWidth
+                height:                     statusLabel.height
+                anchors.margins:            ScreenTools.defaultFontPixelWidth
+                anchors.horizontalCenter:   parent.horizontalCenter
+                QGCLabel {
+                    id:                     statusLabel
+                    text:                   qsTr("Link Status")
+                    font.family:            ScreenTools.demiboldFontFamily
+                }
+            }
+            Rectangle {
+                height:                     statusCol.height + (ScreenTools.defaultFontPixelHeight * 2)
+                width:                      _panelWidth
+                color:                      qgcPal.windowShade
+                anchors.margins:            ScreenTools.defaultFontPixelWidth
+                anchors.horizontalCenter:   parent.horizontalCenter
+                Column {
+                    id:                     statusCol
+                    spacing:                ScreenTools.defaultFontPixelHeight * 0.5
+                    width:                  parent.width
+                    anchors.centerIn:       parent
+                    GridLayout {
+                        anchors.margins:    ScreenTools.defaultFontPixelHeight
+                        columnSpacing:      ScreenTools.defaultFontPixelWidth * 2
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        columns: 2
+                        QGCLabel {
+                            text:           qsTr("Status:")
+                            Layout.preferredWidth: _labelWidth
+                        }
+                        QGCLabel {
+                            text:           _connected ? qsTr("Connected") : qsTr("Not Connected")
+                            color:          _connected ? qgcPal.colorGreen : qgcPal.colorRed
+                            Layout.preferredWidth: _labelWidth
+                        }
+                        QGCLabel {
+                            text:           qsTr("Node Address:")
+                            Layout.minimumWidth: _labelWidth
+                        }
+                        QGCLabel {
+                            text:           rajantManager ? rajantManager.nodeAddress : qsTr("N/A")
+                            Layout.minimumWidth: _valueWidth
+                        }
+                        QGCLabel {
+                            text:           qsTr("Radio:")
+                            visible:        _connected
+                        }
+                        QGCLabel {
+                            text:           rajantManager ? rajantManager.radioName + " (ch " + rajantManager.channel + ")" : ""
+                            visible:        _connected
+                        }
+                        QGCLabel {
+                            text:           qsTr("Signal:")
+                            visible:        _connected
+                        }
+                        QGCLabel {
+                            text:           rajantManager ? rajantManager.signal + " dBm" : ""
+                            visible:        _connected
+                        }
+                        QGCLabel {
+                            text:           qsTr("Noise Floor:")
+                            visible:        _connected
+                        }
+                        QGCLabel {
+                            text:           rajantManager ? rajantManager.noise + " dBm" : ""
+                            visible:        _connected
+                        }
+                        QGCLabel {
+                            text:           qsTr("SNR:")
+                            visible:        _connected
+                        }
+                        QGCLabel {
+                            text:           rajantManager ? rajantManager.snr + " dB" : ""
+                            visible:        _connected
+                        }
+                        QGCLabel {
+                            text:           qsTr("Link Rate:")
+                            visible:        _connected
+                        }
+                        QGCLabel {
+                            text:           rajantManager ? rajantManager.linkRate + " Mbps" : ""
+                            visible:        _connected
+                        }
+                        QGCLabel {
+                            text:           qsTr("Tx Power:")
+                            visible:        _connected
+                        }
+                        QGCLabel {
+                            text:           rajantManager ? rajantManager.txPower + " dBm" : ""
+                            visible:        _connected
+                        }
+                        QGCLabel {
+                            text:           qsTr("Peers:")
+                            visible:        _connected
+                        }
+                        QGCLabel {
+                            text:           rajantManager ? rajantManager.peerCount.toString() : ""
+                            visible:        _connected
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/RajantLink/RajantSettings.qml
+++ b/src/RajantLink/RajantSettings.qml
@@ -19,9 +19,7 @@ Rectangle {
     property real _labelWidth:                  _panelWidth * 0.4
     property real _valueWidth:                  _panelWidth * 0.4
     property var rajantManager:                 QGroundControl.corePlugin.rajantManager
-    property var rajantAirManager:              QGroundControl.corePlugin.rajantAirManager
     property bool _connected:                   rajantManager ? rajantManager.connected && rajantManager.authenticated : false
-    property bool _airConnected:                rajantAirManager ? rajantAirManager.connected && rajantAirManager.authenticated : false
 
     readonly property real _internalWidthRatio:          0.8
 
@@ -76,55 +74,35 @@ Rectangle {
                         QGCLabel {
                             text:           qsTr("Node Address:")
                             Layout.minimumWidth: _labelWidth
-                            visible:        false
                         }
                         QGCLabel {
                             text:           rajantManager ? rajantManager.nodeAddress : qsTr("N/A")
                             Layout.minimumWidth: _valueWidth
-                            visible:        false
                         }
                         QGCLabel {
                             text:           qsTr("Radio:")
-                            visible:        false
+                            visible:        _connected
                         }
                         QGCLabel {
                             text:           rajantManager ? rajantManager.radioName + " (ch " + rajantManager.channel + ")" : ""
-                            visible:        false
+                            visible:        _connected
                         }
                         QGCLabel {
                             text:           qsTr("Signal:")
                             visible:        _connected
                         }
                         QGCLabel {
-                            text:           rajantManager ? rajantManager.signal + " / " + rajantManager.noise + " dBm" : ""
+                            text:           rajantManager ? rajantManager.signal + " dBm" : ""
                             visible:        _connected
                         }
                         QGCLabel {
-                            text:           qsTr("Noise:")
+                            text:           qsTr("Noise Floor:")
                             visible:        _connected
                         }
                         QGCLabel {
                             text:           rajantManager ? rajantManager.noise + " dBm" : ""
                             visible:        _connected
                         }
-
-                        QGCLabel {
-                            text:           qsTr("Sky Signal:")
-                            visible:        _airConnected
-                        }
-                        QGCLabel {
-                            text:           rajantAirManager ? rajantAirManager.signal + " / " + rajantAirManager.noise + " dBm" : ""
-                            visible:        _airConnected
-                        }
-                        QGCLabel {
-                            text:           qsTr("Sky Noise:")
-                            visible:        _airConnected
-                        }
-                        QGCLabel {
-                            text:           rajantAirManager ? rajantAirManager.noise + " dBm" : ""
-                            visible:        _airConnected
-                        }
-
                         QGCLabel {
                             text:           qsTr("SNR:")
                             visible:        _connected
@@ -135,11 +113,11 @@ Rectangle {
                         }
                         QGCLabel {
                             text:           qsTr("Link Rate:")
-                            visible:        false
+                            visible:        _connected
                         }
                         QGCLabel {
                             text:           rajantManager ? rajantManager.linkRate + " Mbps" : ""
-                            visible:        false
+                            visible:        _connected
                         }
                         QGCLabel {
                             text:           qsTr("Tx Power:")
@@ -156,12 +134,6 @@ Rectangle {
                         QGCLabel {
                             text:           rajantManager ? rajantManager.peerCount.toString() : ""
                             visible:        _connected
-                        }
-                        QGCLabel {
-                            text:           qsTr("Version:")
-                        }
-                        QGCLabel {
-                            text:           qsTr("Rajant BCAPI 11.29")
                         }
                     }
                 }

--- a/src/RajantLink/RajantSettings.qml
+++ b/src/RajantLink/RajantSettings.qml
@@ -18,8 +18,14 @@ Rectangle {
     property real _panelWidth:                  _root.width * _internalWidthRatio
     property real _labelWidth:                  _panelWidth * 0.4
     property real _valueWidth:                  _panelWidth * 0.4
-    property var rajantManager:                 QGroundControl.corePlugin.rajantManager
-    property bool _connected:                   rajantManager ? rajantManager.connected && rajantManager.authenticated : false
+    property var  rajantManager:                QGroundControl.corePlugin.rajantManager
+    // Treat a dead mesh link the same as disconnected — UI goes to N/A, not stale values
+    property bool _connected:                   rajantManager ? rajantManager.connected && rajantManager.authenticated && rajantManager.linkLive : false
+    property int  _signal:                      rajantManager ? rajantManager.signal    : 0
+    property int  _noise:                       rajantManager ? rajantManager.noise     : 0
+    property int  _snr:                         rajantManager ? rajantManager.snr       : 0
+    property int  _skySignal:                   rajantManager ? rajantManager.skySignal : 0
+    property int  _skySnr:                      rajantManager ? rajantManager.skySnr    : 0
 
     readonly property real _internalWidthRatio:          0.8
 
@@ -74,25 +80,39 @@ Rectangle {
                         QGCLabel {
                             text:           qsTr("Node Address:")
                             Layout.minimumWidth: _labelWidth
+                            visible:        false
                         }
                         QGCLabel {
                             text:           rajantManager ? rajantManager.nodeAddress : qsTr("N/A")
                             Layout.minimumWidth: _valueWidth
+                            visible:        false
                         }
                         QGCLabel {
                             text:           qsTr("Radio:")
-                            visible:        _connected
+                            visible:        false
                         }
                         QGCLabel {
                             text:           rajantManager ? rajantManager.radioName + " (ch " + rajantManager.channel + ")" : ""
+                            visible:        false
+                        }
+                        QGCLabel {
+                            text:           qsTr("RSSI:")
                             visible:        _connected
                         }
                         QGCLabel {
-                            text:           qsTr("Signal:")
+                            text:           _connected
+                                              ? _signal + " dBm / " + _snr + " dB"
+                                              : ""
                             visible:        _connected
                         }
                         QGCLabel {
-                            text:           rajantManager ? rajantManager.signal + " dBm" : ""
+                            text:           qsTr("Sky RSSI:")
+                            visible:        _connected
+                        }
+                        QGCLabel {
+                            text:           _connected && _skySnr > 0
+                                              ? _skySignal + " dBm / " + _skySnr + " dB"
+                                              : qsTr("N/A")
                             visible:        _connected
                         }
                         QGCLabel {
@@ -100,24 +120,16 @@ Rectangle {
                             visible:        _connected
                         }
                         QGCLabel {
-                            text:           rajantManager ? rajantManager.noise + " dBm" : ""
-                            visible:        _connected
-                        }
-                        QGCLabel {
-                            text:           qsTr("SNR:")
-                            visible:        _connected
-                        }
-                        QGCLabel {
-                            text:           rajantManager ? rajantManager.snr + " dB" : ""
+                            text:           _connected ? _noise + " dBm" : ""
                             visible:        _connected
                         }
                         QGCLabel {
                             text:           qsTr("Link Rate:")
-                            visible:        _connected
+                            visible:        false
                         }
                         QGCLabel {
                             text:           rajantManager ? rajantManager.linkRate + " Mbps" : ""
-                            visible:        _connected
+                            visible:        false
                         }
                         QGCLabel {
                             text:           qsTr("Tx Power:")
@@ -134,6 +146,24 @@ Rectangle {
                         QGCLabel {
                             text:           rajantManager ? rajantManager.peerCount.toString() : ""
                             visible:        _connected
+                        }
+                        QGCLabel {
+                            text:           qsTr("Hostname:")
+                            // visible:        _connected && rajantManager && rajantManager.nodeName.length > 0
+                            visible:        false
+                        }
+                        QGCLabel {
+                            text:           rajantManager ? rajantManager.nodeName : ""
+                            // visible:        _connected && rajantManager && rajantManager.nodeName.length > 0
+                            visible:        false
+                        }
+                        QGCLabel {
+                            text:           qsTr("Firmware:")
+                            visible:        _connected && rajantManager && rajantManager.firmwareVersion.length > 0
+                        }
+                        QGCLabel {
+                            text:           rajantManager ? rajantManager.firmwareVersion : ""
+                            visible:        _connected && rajantManager && rajantManager.firmwareVersion.length > 0
                         }
                     }
                 }

--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -175,7 +175,19 @@ Rectangle {
         anchors.top:        parent.top
         anchors.bottom:     parent.bottom
         anchors.margins:    ScreenTools.defaultFontPixelHeight * 0.66
+        visible:            !QGroundControl.corePlugin.rajantManager
         source:             QGroundControl.corePlugin.m2Manager ? "qrc:/qml/M2LinkIndicator.qml" : "qrc:/toolbar/ARLinkIndicator.qml"
+    }
+    
+    // Rajant BCAPI Link Indicator (shown when Rajant is connected, replaces ARLink/M2)
+    Loader {
+        id:                 rajantLinkIndicator
+        anchors.right:      parent.right
+        anchors.top:        parent.top
+        anchors.bottom:     parent.bottom
+        anchors.margins:    ScreenTools.defaultFontPixelHeight * 0.66
+        visible:            QGroundControl.corePlugin.rajantManager ? true : false
+        source:             visible ? "qrc:/toolbar/RajantLinkIndicator.qml" : ""
     }
 
     // Small parameter download progress bar

--- a/translations/qgc_source_ko_KR.ts
+++ b/translations/qgc_source_ko_KR.ts
@@ -7362,6 +7362,16 @@ Click Ok to start the auto-tuning process.
       <translation>기타</translation>
     </message>
     <message>
+      <location filename="../src/ui/preferences/GeneralSettings.qml" line="782"/>
+      <source>Enable Doodle Labs IP</source>
+      <translation>Doodle Labs IP 활성화</translation>
+    </message>
+    <message>
+      <location filename="../src/ui/preferences/GeneralSettings.qml" line="790"/>
+      <source>Doodle Labs IP</source>
+      <translation>Doodle Labs IP</translation>
+    </message>
+    <message>
       <location filename="../src/ui/preferences/GeneralSettings.qml" line="468"/>
       <source>Language</source>
       <translation>언어</translation>
@@ -19152,6 +19162,154 @@ Confirm change?</source>
         <location filename="../custom/src/ARLink/ARSettings.qml" line="260"/>
         <source>Air Settings</source>
         <translation>공중 장치 설정</translation>
+    </message>
+</context>
+<context>
+
+    <name>RajantSettings</name>
+<message>
+        <location filename="../src/RajantLink/RajantSettings.qml" line="51"/>
+        <source>Link Status</source>
+        <translation>링크 상태</translation>
+    </message>
+<message>
+        <location filename="../src/RajantLink/RajantSettings.qml" line="72"/>
+        <source>Status:</source>
+        <translation>상태:</translation>
+    </message>
+<message>
+        <location filename="../src/RajantLink/RajantSettings.qml" line="76"/>
+        <source>Connected</source>
+        <translation>연결됨</translation>
+    </message>
+<message>
+        <location filename="../src/RajantLink/RajantSettings.qml" line="76"/>
+        <source>Not Connected</source>
+        <translation>연결 안 됨</translation>
+    </message>
+<message>
+        <location filename="../src/RajantLink/RajantSettings.qml" line="81"/>
+        <source>Node Address:</source>
+        <translation>노드 주소:</translation>
+    </message>
+<message>
+        <location filename="../src/RajantLink/RajantSettings.qml" line="86"/>
+        <source>N/A</source>
+        <translation>N/A</translation>
+    </message>
+<message>
+        <location filename="../src/RajantLink/RajantSettings.qml" line="91"/>
+        <source>Radio:</source>
+        <translation>무선기:</translation>
+    </message>
+<message>
+        <location filename="../src/RajantLink/RajantSettings.qml" line="99"/>
+        <source>RSSI:</source>
+        <translation>RSSI:</translation>
+    </message>
+<message>
+        <location filename="../src/RajantLink/RajantSettings.qml" line="109"/>
+        <source>Sky RSSI:</source>
+        <translation>공중 RSSI:</translation>
+    </message>
+<message>
+        <location filename="../src/RajantLink/RajantSettings.qml" line="119"/>
+        <source>Noise Floor:</source>
+        <translation>잡음 수준:</translation>
+    </message>
+<message>
+        <location filename="../src/RajantLink/RajantSettings.qml" line="127"/>
+        <source>Link Rate:</source>
+        <translation>링크 속도:</translation>
+    </message>
+<message>
+        <location filename="../src/RajantLink/RajantSettings.qml" line="135"/>
+        <source>Tx Power:</source>
+        <translation>송신 출력:</translation>
+    </message>
+<message>
+        <location filename="../src/RajantLink/RajantSettings.qml" line="143"/>
+        <source>Peers:</source>
+        <translation>피어:</translation>
+    </message>
+<message>
+        <location filename="../src/RajantLink/RajantSettings.qml" line="151"/>
+        <source>Hostname:</source>
+        <translation>호스트 이름:</translation>
+    </message>
+<message>
+        <location filename="../src/RajantLink/RajantSettings.qml" line="161"/>
+        <source>Firmware:</source>
+        <translation>펌웨어:</translation>
+    </message>
+</context>
+<context>
+
+    <name>RajantLinkIndicator</name>
+<message>
+        <location filename="../src/RajantLink/RajantLinkIndicator.qml" line="59"/>
+        <source>Rajant Link Status</source>
+        <translation>Rajant 링크 상태</translation>
+    </message>
+<message>
+        <location filename="../src/RajantLink/RajantLinkIndicator.qml" line="59"/>
+        <source>Rajant Disconnected</source>
+        <translation>Rajant 연결 끊김</translation>
+    </message>
+<message>
+        <location filename="../src/RajantLink/RajantLinkIndicator.qml" line="70"/>
+        <source>Radio:</source>
+        <translation>무선기:</translation>
+    </message>
+<message>
+        <location filename="../src/RajantLink/RajantLinkIndicator.qml" line="77"/>
+        <source>RSSI:</source>
+        <translation>RSSI:</translation>
+    </message>
+<message>
+        <location filename="../src/RajantLink/RajantLinkIndicator.qml" line="79"/>
+        <location filename="../src/RajantLink/RajantLinkIndicator.qml" line="87"/>
+        <location filename="../src/RajantLink/RajantLinkIndicator.qml" line="93"/>
+        <location filename="../src/RajantLink/RajantLinkIndicator.qml" line="99"/>
+        <location filename="../src/RajantLink/RajantLinkIndicator.qml" line="106"/>
+        <location filename="../src/RajantLink/RajantLinkIndicator.qml" line="113"/>
+        <source>N/A</source>
+        <translation>N/A</translation>
+    </message>
+<message>
+        <location filename="../src/RajantLink/RajantLinkIndicator.qml" line="83"/>
+        <source>Sky RSSI:</source>
+        <translation>공중 RSSI:</translation>
+    </message>
+<message>
+        <location filename="../src/RajantLink/RajantLinkIndicator.qml" line="91"/>
+        <source>Noise:</source>
+        <translation>잡음:</translation>
+    </message>
+<message>
+        <location filename="../src/RajantLink/RajantLinkIndicator.qml" line="97"/>
+        <source>Link Rate:</source>
+        <translation>링크 속도:</translation>
+    </message>
+<message>
+        <location filename="../src/RajantLink/RajantLinkIndicator.qml" line="104"/>
+        <source>Tx Power:</source>
+        <translation>송신 출력:</translation>
+    </message>
+<message>
+        <location filename="../src/RajantLink/RajantLinkIndicator.qml" line="111"/>
+        <source>Peers:</source>
+        <translation>피어:</translation>
+    </message>
+<message>
+        <location filename="../src/RajantLink/RajantLinkIndicator.qml" line="116"/>
+        <source>Main Link:</source>
+        <translation>주 링크:</translation>
+    </message>
+<message>
+        <location filename="../src/RajantLink/RajantLinkIndicator.qml" line="117"/>
+        <source>UDP</source>
+        <translation>UDP</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
- Add Q_OS_ANDROID guarded Linux/Netlink includes in CustomPlugin.cc 
- Android discovery via Rajant SUP multicast protocol (ff02::1 UDP 35057) using raw BSD sockets 
- ARP poke to Ethernet gateway to populate kernel neighbor table before discovery 
- Netlink RTM_GETNEIGH fallback when SUP receives no responses 
- Ground unit identification by matching Ethernet gateway MAC against SUP fe80:: candidates 
- Filter only Ethernet gateways for ground unit matching, skip wlan interfaces 
- Skip Rajant discovery immediately when M2, Enpulse, or DoodleLab is detected 
- Add _rajantDiscoveryRetries counter with retry limit: 5x Android, 5x Windows 
- Windows/Linux discovery paths unchanged (netsh / ip -6 neigh) 
- RajantSettings: label/value widths changed from fixed pixels to relative (40% panel width) 
- RajantSettings: Layout.minimumWidth replaced with Layout.preferredWidth for small screens


