### PR TITLE
bug #7830 [ALES QGC] Parameters missing Message

### DIFF
--- a/src/AutoPilotPlugins/PX4/BatteryParams.qml
+++ b/src/AutoPilotPlugins/PX4/BatteryParams.qml
@@ -27,16 +27,16 @@ QtObject {
     property int batteryIndex   ///< 1-based battery index
 
 
-    property Fact battSource:                   controller.getParameterFact(-1, "BAT#_SOURCE".replace       ("#", _indexedBatteryParamsAvailable ? batteryIndex : ""))
-    property Fact battNumCells:                 controller.getParameterFact(-1, "BAT#_N_CELLS".replace      ("#", _indexedBatteryParamsAvailable ? batteryIndex : ""))
-    property Fact battHighVolt:                 controller.getParameterFact(-1, "BAT#_V_CHARGED".replace    ("#", _indexedBatteryParamsAvailable ? batteryIndex : ""))
-    property Fact battLowVolt:                  controller.getParameterFact(-1, "BAT#_V_EMPTY".replace      ("#", _indexedBatteryParamsAvailable ? batteryIndex : ""))
-    property Fact battVoltLoadDrop:             controller.getParameterFact(-1, "BAT#_V_LOAD_DROP".replace  ("#", _indexedBatteryParamsAvailable ? batteryIndex : ""))
-    property Fact battVoltageDivider:           controller.getParameterFact(-1, "BAT#_V_DIV".replace        ("#", _indexedBatteryParamsAvailable ? batteryIndex : ""), false)
-    property Fact battAmpsPerVolt:              controller.getParameterFact(-1, "BAT#_A_PER_V".replace      ("#", _indexedBatteryParamsAvailable ? batteryIndex : ""), false)
+    property Fact battSource:                   controller.getParameterFact(-1, _batteryParamName("SOURCE"))
+    property Fact battNumCells:                 controller.getParameterFact(-1, _batteryParamName("N_CELLS"))
+    property Fact battHighVolt:                 controller.getParameterFact(-1, _batteryParamName("V_CHARGED"))
+    property Fact battLowVolt:                  controller.getParameterFact(-1, _batteryParamName("V_EMPTY"))
+    property Fact battVoltLoadDrop:             controller.getParameterFact(-1, _batteryParamName("V_LOAD_DROP"))
+    property Fact battVoltageDivider:           controller.getParameterFact(-1, _batteryParamName("V_DIV"), false)
+    property Fact battAmpsPerVolt:              controller.getParameterFact(-1, _batteryParamName("A_PER_V"), false)
 
-    property bool battVoltageDividerAvailable:  controller.parameterExists(-1, "BAT#_V_DIV".replace     ("#", _indexedBatteryParamsAvailable ? batteryIndex : ""))
-    property bool battAmpsPerVoltAvailable:     controller.parameterExists(-1, "BAT#_A_PER_V".replace   ("#", _indexedBatteryParamsAvailable ? batteryIndex : ""))
+    property bool battVoltageDividerAvailable:  controller.parameterExists(-1, _batteryParamName("V_DIV"))
+    property bool battAmpsPerVoltAvailable:     controller.parameterExists(-1, _batteryParamName("A_PER_V"))
 
     property string _batNCellsIndexedParamName:     "BAT#_N_CELLS"
     property bool   _indexedBatteryParamsAvailable: controller.parameterExists(-1, _batNCellsIndexedParamName.replace("#", 1))
@@ -56,5 +56,16 @@ QtObject {
             }
             batteryIndex++
         } while (true)
+    }
+
+    function _batteryParamName(paramSuffix) {
+        if (_indexedBatteryParamsAvailable) {
+            var indexedName = "BAT" + batteryIndex + "_" + paramSuffix
+            if (controller.parameterExists(-1, indexedName) || batteryIndex > 1) {
+                return indexedName
+            }
+        }
+
+        return "BAT_" + paramSuffix
     }
 }

--- a/src/AutoPilotPlugins/PX4/PowerComponent.cc
+++ b/src/AutoPilotPlugins/PX4/PowerComponent.cc
@@ -13,6 +13,31 @@
 
 #include "PowerComponent.h"
 #include "PX4AutoPilotPlugin.h"
+#include "ParameterManager.h"
+
+namespace {
+
+QString _batteryParamName(ParameterManager* parameterManager, const QString& paramSuffix)
+{
+    const QString indexedName = QStringLiteral("BAT1_%1").arg(paramSuffix);
+    if (parameterManager->parameterExists(FactSystem::defaultComponentId, indexedName)) {
+        return indexedName;
+    }
+
+    return QStringLiteral("BAT_%1").arg(paramSuffix);
+}
+
+bool _batteryParamExists(ParameterManager* parameterManager, const QString& paramSuffix)
+{
+    return parameterManager->parameterExists(FactSystem::defaultComponentId, _batteryParamName(parameterManager, paramSuffix));
+}
+
+Fact* _batteryParamFact(ParameterManager* parameterManager, const QString& paramSuffix)
+{
+    return parameterManager->getParameter(FactSystem::defaultComponentId, _batteryParamName(parameterManager, paramSuffix));
+}
+
+}
 
 PowerComponent::PowerComponent(Vehicle* vehicle, AutoPilotPlugin* autopilot, QObject* parent) :
     VehicleComponent(vehicle, autopilot, parent),
@@ -42,21 +67,25 @@ bool PowerComponent::requiresSetup(void) const
 
 bool PowerComponent::setupComplete(void) const
 {
-    if (!_vehicle->parameterManager()->parameterExists(FactSystem::defaultComponentId, "BAT1_SOURCE") ||
-        !_vehicle->parameterManager()->parameterExists(FactSystem::defaultComponentId, "BAT1_V_CHARGED") ||
-        !_vehicle->parameterManager()->parameterExists(FactSystem::defaultComponentId, "BAT1_V_EMPTY") ||
-        !_vehicle->parameterManager()->parameterExists(FactSystem::defaultComponentId, "BAT1_N_CELLS")) {
+    ParameterManager* parameterManager = _vehicle->parameterManager();
+    if (!_batteryParamExists(parameterManager, QStringLiteral("SOURCE")) ||
+        !_batteryParamExists(parameterManager, QStringLiteral("V_CHARGED")) ||
+        !_batteryParamExists(parameterManager, QStringLiteral("V_EMPTY")) ||
+        !_batteryParamExists(parameterManager, QStringLiteral("N_CELLS"))) {
         return true;
     }
-    return _vehicle->parameterManager()->getParameter(FactSystem::defaultComponentId, "BAT1_SOURCE")->rawValue().toInt() == -1 ||
-        (_vehicle->parameterManager()->getParameter(FactSystem::defaultComponentId, "BAT1_V_CHARGED")->rawValue().toFloat() != 0.0f &&
-        _vehicle->parameterManager()->getParameter(FactSystem::defaultComponentId, "BAT1_V_EMPTY")->rawValue().toFloat() != 0.0f &&
-        _vehicle->parameterManager()->getParameter(FactSystem::defaultComponentId, "BAT1_N_CELLS")->rawValue().toInt() != 0);
+    return _batteryParamFact(parameterManager, QStringLiteral("SOURCE"))->rawValue().toInt() == -1 ||
+        (_batteryParamFact(parameterManager, QStringLiteral("V_CHARGED"))->rawValue().toFloat() != 0.0f &&
+        _batteryParamFact(parameterManager, QStringLiteral("V_EMPTY"))->rawValue().toFloat() != 0.0f &&
+        _batteryParamFact(parameterManager, QStringLiteral("N_CELLS"))->rawValue().toInt() != 0);
 }
 
 QStringList PowerComponent::setupCompleteChangedTriggerList(void) const
 {
-    return {"BAT1_SOURCE", "BAT1_V_CHARGED", "BAT1_V_EMPTY", "BAT1_N_CELLS"};
+    return {
+        "BAT1_SOURCE", "BAT1_V_CHARGED", "BAT1_V_EMPTY", "BAT1_N_CELLS",
+        "BAT_SOURCE", "BAT_V_CHARGED", "BAT_V_EMPTY", "BAT_N_CELLS"
+    };
 }
 
 QUrl PowerComponent::setupSource(void) const

--- a/src/AutoPilotPlugins/PX4/PowerComponentSummary.qml
+++ b/src/AutoPilotPlugins/PX4/PowerComponentSummary.qml
@@ -26,9 +26,14 @@ Item {
     QGCPalette { id: qgcPal; colorGroupEnabled: enabled }
     FactPanelController { id: controller; }
 
-    property Fact batVChargedFact:  controller.getParameterFact(-1, "BAT1_V_CHARGED")
-    property Fact batVEmptyFact:    controller.getParameterFact(-1, "BAT1_V_EMPTY")
-    property Fact batCellsFact:     controller.getParameterFact(-1, "BAT1_N_CELLS")
+    function batteryParamName(paramSuffix) {
+        var indexedName = "BAT1_" + paramSuffix
+        return controller.parameterExists(-1, indexedName) ? indexedName : "BAT_" + paramSuffix
+    }
+
+    property Fact batVChargedFact:  controller.getParameterFact(-1, batteryParamName("V_CHARGED"))
+    property Fact batVEmptyFact:    controller.getParameterFact(-1, batteryParamName("V_EMPTY"))
+    property Fact batCellsFact:     controller.getParameterFact(-1, batteryParamName("N_CELLS"))
 
     Column {
         anchors.fill:       parent

--- a/src/FirmwarePlugin/PX4/PX4ParameterFactMetaData.xml
+++ b/src/FirmwarePlugin/PX4/PX4ParameterFactMetaData.xml
@@ -679,6 +679,16 @@
     <parameter name="BAT_N_CELLS" default="3" type="INT32" category="System">
       <short_desc>This parameter is deprecated. Please use BAT1_N_CELLS instead</short_desc>
     </parameter>
+    <parameter name="BAT_SOURCE" default="0" type="INT32" category="System">
+      <short_desc>This parameter is deprecated. Please use BAT1_SOURCE instead</short_desc>
+      <long_desc>Battery monitoring source. The value 'Power Module' means that measurements are expected to come from a power module. If the value is set to 'External' then the system expects to receive MAVLink battery status messages.</long_desc>
+      <min>0</min>
+      <max>1</max>
+      <values>
+        <value code="0">Power Module</value>
+        <value code="1">External</value>
+      </values>
+    </parameter>
     <parameter name="BAT_V_CHARGED" default="4.05" type="FLOAT" category="System">
       <short_desc>This parameter is deprecated. Please use BAT1_V_CHARGED instead</short_desc>
     </parameter>
@@ -692,6 +702,17 @@
       <short_desc>Offset in volt as seen by the ADC input of the current sensor</short_desc>
       <long_desc>This offset will be subtracted before calculating the battery current based on the voltage.</long_desc>
       <decimal>8</decimal>
+    </parameter>
+    <parameter name="BAT1_SOURCE" default="0" type="INT32" category="System">
+      <short_desc>Battery 1 monitoring source</short_desc>
+      <long_desc>This parameter controls the source of battery data. The value 'Power Module' means that measurements are expected to come from a power module. If the value is set to 'External' then the system expects to receive MAVLink battery status messages. If the value is set to 'ESCs', the battery information is taken from the esc_status message.</long_desc>
+      <reboot_required>true</reboot_required>
+      <values>
+        <value code="-1">Disabled</value>
+        <value code="0">Power Module</value>
+        <value code="1">External</value>
+        <value code="2">ESCs</value>
+      </values>
     </parameter>
   </group>
   <group name="Camera Capture">


### PR DESCRIPTION
Bug: #7830 (https://argosdyne.mytuleap.com/plugins/tracker/?aid=7830)

[ALES QGC] Parameters missing Message

Cause:
Power tab assumed indexed PX4 battery parameters when BAT1_N_CELLS exists and then requested BAT1_SOURCE directly. Some firmware exposes a mixed set where BAT1_N_CELLS exists but source remains BAT_SOURCE, which caused the missing parameter popup.

Solution:
- Add per-parameter fallback from BAT1_* to BAT_* for PX4 Power battery params.
- Update Power setup completion and summary logic to support both naming schemes.
- Add BAT_SOURCE and BAT1_SOURCE enum metadata so the Source combo displays labels such as External correctly.