### PR TITLE
Add: Enable Doodle Labs IP checkbox to toggle IP row visibility in General Settings

### DIFF
--- a/custom/src/Custom.SettingsGroup.json
+++ b/custom/src/Custom.SettingsGroup.json
@@ -30,6 +30,12 @@
     "shortDesc":        "Doodle Labs IP Address",
     "type":             "string",
     "default":          "192.168.2.72"
+},
+{
+    "name":             "doodleLabsIPEnable",
+    "shortDesc":        "Enable Doodle Labs IP",
+    "type":             "bool",
+    "default":          false
 }
 ]
 }

--- a/custom/src/CustomSettings.cc
+++ b/custom/src/CustomSettings.cc
@@ -9,6 +9,7 @@ DECLARE_SETTINGGROUP(Custom, "Custom")
 DECLARE_SETTINGSFACT(CustomSettings, is3DMap)
 DECLARE_SETTINGSFACT(CustomSettings, rtcmSource)
 DECLARE_SETTINGSFACT(CustomSettings, doodleLabsIP)
+DECLARE_SETTINGSFACT(CustomSettings, doodleLabsIPEnable)
 
 DECLARE_SETTINGSFACT_NO_FUNC(CustomSettings, teamMode)
 {

--- a/custom/src/CustomSettings.h
+++ b/custom/src/CustomSettings.h
@@ -13,4 +13,5 @@ public:
     DEFINE_SETTINGFACT(rtcmSource)
     DEFINE_SETTINGFACT(teamMode)
     DEFINE_SETTINGFACT(doodleLabsIP)
+    DEFINE_SETTINGFACT(doodleLabsIPEnable)
 };

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -778,8 +778,14 @@ Rectangle {
                                     property Fact _remoteIDEnable: QGroundControl.settingsManager.remoteIDSettings.enable
                                 }
 
+                                FactCheckBox {
+                                    text: qsTr("Enable Doodle Labs IP")
+                                    fact: QGroundControl.corePlugin.settings.doodleLabsIPEnable
+                                }
+
                                 RowLayout {
                                     spacing: _margins
+                                    visible: QGroundControl.corePlugin.settings.doodleLabsIPEnable.value
                                     QGCLabel {
                                         text: qsTr("Doodle Labs IP")
                                     }


### PR DESCRIPTION
https://argosdyne.mytuleap.com/plugins/tracker/?aid=7834


- The "Doodle Labs IP" field in Settings → General → Miscellaneous was always visible, cluttering the UI for users without a Doodle Labs radio. 
- Added a persistent "Enable Doodle Labs IP" checkbox (doodleLabsIPEnable, default false) that gates the IP row's visibility. 
- Follows the same pattern as the existing Disable FPV Video / fpvUrl toggle.


