### PR TITLE
bug 7767 - Fix: swapped distance/landTime args in RTL mission time calc to V02.02.00

### DIFF
--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -1747,7 +1747,7 @@ void MissionController::_recalcMissionFlightStatus()
         double hoverTime = distance / _missionFlightStatus.hoverSpeed;
         double cruiseTime = distance / _missionFlightStatus.cruiseSpeed;
         double landTime = qAbs(altDifference) / _appSettings->offlineEditingDescentSpeed()->rawValue().toDouble();
-        _addTimeDistance(_missionFlightStatus.vtolMode == QGCMAVLink::VehicleClassMultiRotor, hoverTime, cruiseTime, distance, landTime, -1);
+        _addTimeDistance(_missionFlightStatus.vtolMode == QGCMAVLink::VehicleClassMultiRotor, hoverTime, cruiseTime, landTime, distance, -1);
     }
 
     if (_missionFlightStatus.mAhBattery != 0 && _missionFlightStatus.batteryChangePoint == -1) {

--- a/src/Settings/App.SettingsGroup.json
+++ b/src/Settings/App.SettingsGroup.json
@@ -34,7 +34,7 @@
     "shortDesc": "Offline editing hover speed",
     "longDesc":  "This value defines the default speed for calculating mission statistics for multi-rotor vehicles or VTOL vehicle in multi-rotor mode. It does not modify the flight speed for a specific flight plan.",
     "type":             "double",
-    "default":     5.0,
+    "default":     10.0,
     "min":              1.0,
     "units":            "m/s",
     "decimalPlaces":    2


### PR DESCRIPTION
https://argosdyne.mytuleap.com/plugins/tracker/?aid=7767

Fix mission time inflated by ~30 min when RTL added

Swapped distance/landTime args in _addTimeDistance call at MissionController.cc:1750 so RTL leg uses the same arg order as waypoint legs.
