### PR TITLE
Disable LRF UI using SonyCamera

### DIFF
--- a/src/Camera/CodevCameraVisual.qml
+++ b/src/Camera/CodevCameraVisual.qml
@@ -35,6 +35,19 @@ Item {
     property bool aiInThermal: !(!_aiSource || _aiSource.enumIndex === 0)
     property var aiParentItem: aiInThermal ? thermalOverlayItem : videoContentOverlayItem
 
+    property string _cameraModelUpper: _camera ? ((_camera.modelName || "").toUpperCase()) : ""
+        property string _cameraVendorUpper: _camera ? ((_camera.vendor || "").toUpperCase()) : ""
+    property bool _isSonyIR1: _camera && (
+                                       _cameraVendorUpper.indexOf("SONY") !== -1 ||
+                                       _cameraModelUpper.indexOf("SONY") !== -1 ||
+                                       _cameraModelUpper.indexOf("IR1") !== -1 ||
+                                       _cameraModelUpper.indexOf("IR-1") !== -1 ||
+                                       _cameraModelUpper.indexOf("IR_1") !== -1 ||
+                                       _cameraModelUpper.indexOf("IR 1") !== -1 ||
+                                       _cameraModelUpper.indexOf("LR1") !== -1)
+
+    property bool _hasLaserRangefinder: !_isSonyIR1 && !!_tofEN && (!_tofEN.readOnly || !!_tofEN.value || (_camera && _camera.targetDistance > 0))
+
     function _ensureTrackingDefaults() {
         if (_smartSelect && _smartSelect.value === "None") {
             _smartSelect.value = "Yolov8"
@@ -450,7 +463,7 @@ Item {
         ToolRadioButton {
             Layout.alignment:  Qt.AlignVCenter | Qt.AlignHCenter
             checked: _tofEN ? _tofEN.value : false
-            visible: _tofEN
+            visible: _hasLaserRangefinder
             source: "qrc:/qmlimages/rangefinder.svg"
             onClicked: {
                 _tofEN.value = !_tofEN.value

--- a/src/Camera/QGCCameraControl.cc
+++ b/src/Camera/QGCCameraControl.cc
@@ -16,6 +16,9 @@
 #include "QGCCorePlugin.h"
 
 #include <QDir>
+#include <QCryptographicHash>
+#include <QFileInfo>
+#include <QRegularExpression>
 #include <QStandardPaths>
 #include <QDomDocument>
 #include <QDomNodeList>
@@ -63,6 +66,36 @@ static const char* kPhotoLapse      = "PhotoLapse";
 static const char* kPhotoLapseCount = "PhotoLapseCount";
 static const char* kThermalOpacity  = "ThermalOpacity";
 static const char* kThermalMode     = "ThermalMode";
+
+static QString _cameraDefinitionUri(const mavlink_camera_information_t* info)
+{
+    QByteArray uri(reinterpret_cast<const char*>(info->cam_definition_uri), sizeof(info->cam_definition_uri));
+    const int nullIndex = uri.indexOf('\0');
+    if (nullIndex >= 0) {
+        uri.truncate(nullIndex);
+    }
+    return QString::fromUtf8(uri);
+}
+
+static QString _mavlinkFixedString(const uint8_t* data, int maxLen)
+{
+    QByteArray raw(reinterpret_cast<const char*>(data), maxLen);
+    const int nullIndex = raw.indexOf('\0');
+    if (nullIndex >= 0) {
+        raw.truncate(nullIndex);
+    }
+    return QString::fromUtf8(raw);
+}
+
+static QString _mavlinkFixedString(const char* data, int maxLen)
+{
+    QByteArray raw(data, maxLen);
+    const int nullIndex = raw.indexOf('\0');
+    if (nullIndex >= 0) {
+        raw.truncate(nullIndex);
+    }
+    return QString::fromUtf8(raw);
+}
 
 //-----------------------------------------------------------------------------
 // Known Parameters
@@ -165,14 +198,18 @@ QGCCameraControl::QGCCameraControl(const mavlink_camera_information_t *info, Veh
     QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
     memcpy(&_info, info, sizeof(mavlink_camera_information_t));
     connect(this, &QGCCameraControl::dataReady, this, &QGCCameraControl::_dataReady);
-    _vendor = QString(reinterpret_cast<const char*>(info->vendor_name));
-    _modelName = QString(reinterpret_cast<const char*>(info->model_name));
+    _vendor = _mavlinkFixedString(info->vendor_name, sizeof(info->vendor_name));
+    _modelName = _mavlinkFixedString(info->model_name, sizeof(info->model_name));
     int ver = static_cast<int>(_info.cam_definition_version);
-    _cacheFile = QString::asprintf("%s/%s_%s_%03d.xml",
-        qgcApp()->toolbox()->settingsManager()->appSettings()->parameterSavePath().toStdString().c_str(),
-        _vendor.toStdString().c_str(),
-        _modelName.toStdString().c_str(),
-        ver);
+    const QString definitionUri = _cameraDefinitionUri(info);
+    const QString uriHash = QString::fromLatin1(QCryptographicHash::hash(definitionUri.toUtf8(), QCryptographicHash::Sha1).toHex().left(12));
+    const QString cacheBaseName = QStringLiteral("%1_%2_%3_%4")
+                                      .arg(_vendor)
+                                      .arg(_modelName)
+                                      .arg(ver, 3, 10, QLatin1Char('0'))
+                                      .arg(uriHash);
+    _cacheFile = QStringLiteral("%1/%2.xml")
+                     .arg(qgcApp()->toolbox()->settingsManager()->appSettings()->parameterSavePath(), cacheBaseName);
     if(info->cam_definition_uri[0] != 0) {
         //-- Process camera definition file
         _handleDefinitionFile(info->cam_definition_uri);
@@ -1638,6 +1675,7 @@ void
 QGCCameraControl::handleVideoInfo(const mavlink_video_stream_information_t* vi)
 {
     qCDebug(CameraControlLog) << "handleVideoInfo:" << vi->stream_id << vi->uri;
+    _checkRtspChangeAndInvalidateCache(_mavlinkFixedString(vi->uri, sizeof(vi->uri)));
     _expectedCount = vi->count;
     qInfo() << "THERMAL_TRACE"
             << "handleVideoInfo"
@@ -1698,6 +1736,85 @@ QGCCameraControl::handleVideoInfo(const mavlink_video_stream_information_t* vi)
         resumeStream();
         emit autoStreamChanged();
         emit _vehicle->cameraManager()->streamChanged();
+    }
+}
+
+QString QGCCameraControl::_cameraRtspSettingsKey() const
+{
+    // Compare by vehicle/component so camera model/vendor changes are still detected.
+    return QStringLiteral("Camera/LastRtsp/%1/%2")
+        .arg(_vehicle ? _vehicle->id() : -1)
+        .arg(_compID);
+}
+
+void QGCCameraControl::_checkRtspChangeAndInvalidateCache(const QString& streamUri)
+{
+    if (!streamUri.startsWith(QStringLiteral("rtsp://"), Qt::CaseInsensitive)) {
+        return;
+    }
+
+    QSettings settings;
+    const QString key = _cameraRtspSettingsKey();
+    const QString previousUri = settings.value(key).toString();
+    if (previousUri.isEmpty()) {
+        settings.setValue(key, streamUri);
+        return;
+    }
+
+    if (previousUri.compare(streamUri, Qt::CaseInsensitive) == 0) {
+        return;
+    }
+
+    qWarning() << "[CameraControl]"
+               << "RTSP URI changed, invalidating camera definition cache"
+               << "compId" << _compID
+               << "previous" << previousUri
+               << "current" << streamUri;
+    _purgeCameraDefinitionCache();    
+    _cached = false;
+    settings.setValue(key, streamUri);
+
+    const QString definitionUri = _cameraDefinitionUri(&_info);
+    if (!definitionUri.isEmpty()) {
+        _handleDefinitionFile(definitionUri);
+    }
+}
+
+void QGCCameraControl::_purgeCameraDefinitionCache()
+{
+    const QString parameterSavePath = qgcApp()->toolbox()->settingsManager()->appSettings()->parameterSavePath();
+    if (parameterSavePath.isEmpty()) {
+        return;
+    }
+
+    QDir cacheDir(parameterSavePath);
+    if (!cacheDir.exists()) {
+        return;
+    }
+
+    // Remove the active cache file first.
+    if (QFile::exists(_cacheFile) && !QFile::remove(_cacheFile)) {
+        qWarning() << "[CameraControl] Failed to remove active cache file:" << _cacheFile;
+    }
+
+    // Remove legacy/new camera definition cache files:
+    //   vendor_model_001.xml
+    //   vendor_model_001_<hash>.xml
+    const QRegularExpression pattern(QStringLiteral("^.+_.+_\\d{3}(?:_[0-9a-fA-F]{12})?\\.xml$"));
+
+    const QFileInfoList files = cacheDir.entryInfoList(QDir::Files | QDir::Readable | QDir::NoSymLinks);
+    for (const QFileInfo& fileInfo : files) {
+        if (fileInfo.absoluteFilePath().compare(_cacheFile, Qt::CaseInsensitive) == 0) {
+            continue;
+        }
+        if (!pattern.match(fileInfo.fileName()).hasMatch()) {
+            continue;
+        }
+        if (!QFile::remove(fileInfo.absoluteFilePath())) {
+            qWarning() << "[CameraControl] Failed to remove cache file:" << fileInfo.absoluteFilePath();
+        } else {
+            qInfo() << "[CameraControl] Removed cache file:" << fileInfo.absoluteFilePath();
+        }
     }
 }
 
@@ -2182,15 +2299,13 @@ QGCCameraControl::_handleDefinitionFile(const QString &url)
                 << "compId" << _compID
                 << "cacheFile" << _cacheFile
                 << "url" << url;
-        int ver = static_cast<int>(_info.cam_definition_version);
         QString ext = "";
         if (url.endsWith(".lzma", Qt::CaseInsensitive)) { ext = ".lzma"; }
         if (url.endsWith(".xz", Qt::CaseInsensitive)) { ext = ".xz"; }
-        QString fileName = QString::asprintf("%s_%s_%03d.xml%s",
-            _vendor.toStdString().c_str(),
-            _modelName.toStdString().c_str(),
-            ver,
-            ext.toStdString().c_str());
+        QString fileName = QFileInfo(_cacheFile).fileName();
+        if (!ext.isEmpty()) {
+            fileName += ext;
+        }
         connect(_vehicle->ftpManager(), &FTPManager::downloadComplete, this, &QGCCameraControl::_ftpDownloadComplete);
         _vehicle->ftpManager()->download(_compID, url,
             qgcApp()->toolbox()->settingsManager()->appSettings()->parameterSavePath().toStdString().c_str(),

--- a/src/Camera/QGCCameraControl.h
+++ b/src/Camera/QGCCameraControl.h
@@ -405,6 +405,10 @@ protected slots:
     virtual void    _checkForVideoStreams   ();
 
 private:
+    QString _cameraRtspSettingsKey          () const;
+    void    _checkRtspChangeAndInvalidateCache(const QString& streamUri);
+    void    _purgeCameraDefinitionCache     ();    
+
     bool    _handleLocalization             (QByteArray& bytes);
     bool    _replaceLocaleStrings           (const QDomNode node, QByteArray& bytes);
     bool    _loadCameraDefinitionFile       (QByteArray& bytes);

--- a/src/Camera/QGCCameraManager.cc
+++ b/src/Camera/QGCCameraManager.cc
@@ -150,17 +150,21 @@ QGCCameraManager::_cameraDefinitionUpstreamUrl(int compID) const
     const QString rtspUrl = qgcApp()->toolbox()->settingsManager()->videoSettings()->rtspUrl()->rawValue().toString();
     const QUrl videoUrl(rtspUrl);
     if (!videoUrl.host().isEmpty()) {
-        int port = videoUrl.port();
+        QString path = videoUrl.path();               
+        QString lastSegment = path.section('/', -1);  
 
-        if(port == -1)
-            port = 554;
+        qInfo() << "[CameraManager] Path =" << path
+                << "LastSegment =" << lastSegment
+                << "RTSPURL =" << rtspUrl;
 
-        if(port == 8554)
-        {
-            return QStringLiteral("http://%1/Codev_R3_023.xml").arg(videoUrl.host()); // Rythmn3
+        if (lastSegment.compare("eo", Qt::CaseInsensitive) == 0) {
+            return QStringLiteral("http://%1/Codev_R3_023.xml").arg(videoUrl.host());   // EO → R3
         }
-        else {
-            return QStringLiteral("http://%1/Codev_RLR1_013.xml").arg(videoUrl.host()); // Sony ILX-LR1
+        else if (lastSegment.compare("cr", Qt::CaseInsensitive) == 0) {
+            return QStringLiteral("http://%1/Codev_RLR1_013.xml").arg(videoUrl.host()); // CR → LR1
+        }
+        else {            
+            return QStringLiteral("http://%1/Codev_RLR1_013.xml").arg(videoUrl.host());
         }
     }
 


### PR DESCRIPTION
Fix: Where the previous XML file remained after changing the camera, causing the camera settings to fail to load.


[bug #7849[ALES QGC] AB120KR + APM + SONY 카메라 조합에서 거리 측정 아이콘 출력](https://argosdyne.mytuleap.com/plugins/tracker/?aid=7849&project-dashboard-id=97)