### PR TITLE
Fix bug #7864 조종기에서 ALES QGC 실행 중 USB 충전 케이블 연결

### DIFF
--- a/android/src/com/hoho/android/usbserial/driver/UsbSerialProber.java
+++ b/android/src/com/hoho/android/usbserial/driver/UsbSerialProber.java
@@ -219,6 +219,13 @@ public enum UsbSerialProber {
      * @return {@code true} if supported
      */
     private static boolean testIfSupported(final UsbDevice usbDevice, final Map<Integer, int[]> supportedDevices) {
+        // Ignore the Codev RC CDC interface so Android does not prompt for USB permission
+        // when the RC/charger is attached.
+        if ("codev".equalsIgnoreCase(usbDevice.getManufacturerName())
+                && "codev rc cdc".equalsIgnoreCase(usbDevice.getProductName())) {
+            return false;
+        }
+
         return supportedDevices.containsKey(usbDevice.getVendorId());
     }
 }


### PR DESCRIPTION
Fix bug #[7864 ](https://argosdyne.mytuleap.com/plugins/tracker/?aid=7864)조종기에서 ALES QGC 실행 중 USB 충전 케이블 연결