### PR TITLE
Secure Setup can still play streaming video even if you enter an incorrect URL

### DIFF
--- a/custom/CustomCameraControl.qml
+++ b/custom/CustomCameraControl.qml
@@ -26,6 +26,7 @@ import QGroundControl.FlightMap         1.0
 import QGroundControl.Palette           1.0
 import QGroundControl.ScreenTools       1.0
 import QGroundControl.Vehicle           1.0
+import CustomQmlInterface               1.0
 
 //import CustomQuickInterface             1.0
 //import Custom.Widgets                   1.0
@@ -69,6 +70,16 @@ Item {
     property bool   _hasGimbal:             activeVehicle && activeVehicle.gimbalData
     property Fact   _viewproPip:            _camera ? _camera.getFact("PIP MODE") : null
     property Fact   _viewproColorPalette:   _camera ? _camera.getFact("IR MODE") : null
+    property Fact   _aviatorUsbOutFact:     (typeof AVIATORInterface !== "undefined" && AVIATORInterface) ? AVIATORInterface.usbOut : null
+    property Fact   _aviatorVersionFact:    (typeof AVIATORInterface !== "undefined" && AVIATORInterface) ? AVIATORInterface.version : null
+    property Fact   _cameraUsbConnectionModeFact: _findFactByKeywords(["usb connection mode", "usb mode", "pc remote", "usb out", "rc_usb_out"], ["RC_USB_OUT", "USB Connection Mode", "USB_MODE"])
+    property Fact   _usbConnectionModeFact: _cameraUsbConnectionModeFact ? _cameraUsbConnectionModeFact : _aviatorUsbOutFact
+    property Fact   _cameraVersionFact:     _findFactByKeywords(["camera version", "firmware version", "rc_version", "version"], ["RC_VERSION", "Camera Version", "Firmware Version"])
+    property Fact   _displayUsbFact:        _usbConnectionModeFact ? _usbConnectionModeFact : _aviatorUsbOutFact
+    property string _displayVersion:        _cameraVersionFact ? _cameraVersionFact.valueString : ((_camera && _camera.firmwareVersion !== "") ? _camera.firmwareVersion : (_aviatorVersionFact ? _aviatorVersionFact.valueString : ""))
+    property double _localRecordStartMs:    0
+    property int    _localRecordElapsedMs:  0
+    property string _localRecordTimeStr:    _formatElapsed(_localRecordElapsedMs)
 
     function capitalize(str) {
         var strs = str
@@ -82,6 +93,78 @@ Item {
                     "camera=", _camera ? _camera.modelName : "null",
                     "paramComplete=", _camera ? _camera.paramComplete : false,
                     "activeSettings=", _camera ? _camera.activeSettings : [])
+    function _findFactByKeywords(keywords, fallbackFactNames) {
+        if (!_camera) {
+            return null
+        }
+
+        if (_camera.paramComplete && _camera.activeSettings) {
+            for (var i = 0; i < _camera.activeSettings.length; i++) {
+                var settingName = _camera.activeSettings[i]
+                var fact = _camera.getFact(settingName)
+                if (!fact) {
+                    continue
+                }
+
+                var haystack = (settingName + " " + fact.name + " " + fact.shortDescription).toLowerCase()
+                for (var j = 0; j < keywords.length; j++) {
+                    if (haystack.indexOf(keywords[j]) !== -1) {
+                        return fact
+                    }
+                }
+            }
+        }
+
+        if (fallbackFactNames) {
+            for (var k = 0; k < fallbackFactNames.length; k++) {
+                try {
+                    var fallbackFact = _camera.getFact(fallbackFactNames[k])
+                    if (fallbackFact) {
+                        return fallbackFact
+                    }
+                } catch (e) {
+                }
+            }
+        }
+
+        return null
+    }
+
+    function _usbModeDisplayText(fact) {
+        if (!fact) {
+            return ""
+        }
+
+        if (fact.enumStrings && fact.enumStrings.length > 0) {
+            return fact.enumOrValueString
+        }
+
+        var mode = parseInt(fact.value)
+        switch (mode) {
+        case 0: return qsTr("Sel. When Connect")
+        case 1: return qsTr("USB Streaming")
+        case 2: return qsTr("MassStorage (MSC)")
+        case 3: return qsTr("MTP")
+        case 4: return qsTr("PC Remote")
+        default: return fact.valueString
+        }
+    }
+
+    function _formatElapsed(ms) {
+        var total = Math.floor(ms / 1000)
+        var h = Math.floor(total / 3600)
+        var m = Math.floor((total % 3600) / 60)
+        var s = total % 60
+        function pad(v) { return v < 10 ? ("0" + v) : ("" + v) }
+        return pad(h) + ":" + pad(m) + ":" + pad(s)
+    }
+
+    Timer {
+        id:                 _localRecordTimer
+        interval:           500
+        repeat:             true
+        running:            _fallbackVideoAvailable && _videoManager && _videoManager.recording
+        onTriggered:        _localRecordElapsedMs = Math.max(0, Date.now() - _localRecordStartMs)
     }
 
     Connections {
@@ -739,6 +822,64 @@ Item {
                         height:     1
                         width:      cameraSettingsCol.width
                         visible:    _isCamera && _camera.streamLabels.length > 1
+                    }
+                    //-------------------------------------------
+                    //-- USB Connection Mode
+                    Row {
+                        spacing:        ScreenTools.defaultFontPixelWidth
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        visible:        _camera && _displayUsbFact
+                        property bool   _isCombo: _displayUsbFact && _displayUsbFact.enumStrings.length > 0
+                        QGCLabel {
+                            text:       qsTr("USB Connection Mode")
+                            width:      _labelFieldWidth
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+                        FactComboBox {
+                            width:      parent._isCombo ? _editFieldWidth : 0
+                            height:     parent._isCombo ? _editFieldHeight : 0
+                            fact:       _displayUsbFact
+                            indexModel: false
+                            visible:    parent._isCombo && _displayUsbFact === _usbConnectionModeFact
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+                        QGCLabel {
+                            visible:    !parent._isCombo
+                            width:      !parent._isCombo ? _editFieldWidth : 0
+                            text:       _usbModeDisplayText(_displayUsbFact)
+                            anchors.verticalCenter: parent.verticalCenter
+                            elide:      Text.ElideRight
+                        }
+                    }
+                    Rectangle {
+                        color:      qgcPal.button
+                        height:     1
+                        width:      cameraSettingsCol.width
+                        visible:    _camera && _displayUsbFact
+                    }
+                    //-------------------------------------------
+                    //-- Camera Version
+                    Row {
+                        spacing:        ScreenTools.defaultFontPixelWidth
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        visible:        _camera && _displayVersion !== ""
+                        QGCLabel {
+                            text:       qsTr("Version")
+                            width:      _labelFieldWidth
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+                        QGCLabel {
+                            text:       _displayVersion
+                            width:      _editFieldWidth
+                            anchors.verticalCenter: parent.verticalCenter
+                            elide:      Text.ElideRight
+                        }
+                    }
+                    Rectangle {
+                        color:      qgcPal.button
+                        height:     1
+                        width:      cameraSettingsCol.width
+                        visible:    _camera && _displayVersion !== ""
                     }
                     //-------------------------------------------
                     //-- Thermal Modes

--- a/custom/CustomCameraControl.qml
+++ b/custom/CustomCameraControl.qml
@@ -93,6 +93,8 @@ Item {
                     "camera=", _camera ? _camera.modelName : "null",
                     "paramComplete=", _camera ? _camera.paramComplete : false,
                     "activeSettings=", _camera ? _camera.activeSettings : [])
+    }
+
     function _findFactByKeywords(keywords, fallbackFactNames) {
         if (!_camera) {
             return null

--- a/custom/qgroundcontrol.qrc
+++ b/custom/qgroundcontrol.qrc
@@ -51,6 +51,7 @@
 		<file alias="FlightDisplayViewUVC.qml">../src/FlightDisplay/FlightDisplayViewUVC.qml</file>
 		<file alias="FWLandingPatternEditor.qml">../src/PlanView/FWLandingPatternEditor.qml</file>
 		<file alias="GeneralSettings.qml">../src/ui/preferences/GeneralSettings.qml</file>
+		<file alias="VideoSettingsPage.qml">../src/ui/preferences/VideoSettingsPage.qml</file>
 		<file alias="CodevCameraVisual.qml">../src/Camera/CodevCameraVisual.qml</file>
 		<file alias="M2Settings.qml">../src/M2Link/M2Settings.qml</file>
 		<!--<flie alias="QGCBusyIndicator.qml">../src/QmlControls/QGCBusyIndicator.qml</flie> -->

--- a/custom/src/CustomPlugin.cc
+++ b/custom/src/CustomPlugin.cc
@@ -172,6 +172,7 @@ CustomPlugin::settingsPages()
 {
     if(_customSettingsList.isEmpty()) {
         _addSettingsEntry(tr("General"),     "qrc:/qml/GeneralSettings.qml",     "qrc:/res/gear-white.svg");
+        _addSettingsEntry(tr("Video"),       "qrc:/qml/VideoSettingsPage.qml",   "qrc:/custom/img/camera_photo.svg");
         _addSettingsEntry(tr("Comm Links"),  "qrc:/qml/LinkSettings.qml",        "qrc:/res/waves.svg");
         _addSettingsEntry(tr("Offline Maps"),"qrc:/qml/OfflineMap.qml",          "qrc:/res/waves.svg");
         _addSettingsEntry(tr("Yellow Scan"), "qrc:/qml/YSSettings.qml",   "qrc:/res/cameraSetting.svg");

--- a/src/Camera/CodevCameraVisual.qml
+++ b/src/Camera/CodevCameraVisual.qml
@@ -352,6 +352,9 @@ Item {
                    _camera.trackingEnabled = true
                 }
             }
+            onTouchDoubleClicked: {
+                QGroundControl.videoManager.fullScreen = !QGroundControl.videoManager.fullScreen
+            }
         }
     }
 

--- a/src/FirstRunPromptDialogs/SecureConnectionFirstRunPrompt.qml
+++ b/src/FirstRunPromptDialogs/SecureConnectionFirstRunPrompt.qml
@@ -15,6 +15,7 @@ import QGroundControl           1.0
 import QGroundControl.Controls  1.0
 import QGroundControl.FactSystem 1.0
 import QGroundControl.ScreenTools 1.0
+import QGroundControl.FactControls 1.0
 
 FirstRunPrompt {
     id:         root
@@ -321,9 +322,9 @@ FirstRunPrompt {
                                 Layout.fillWidth: true
                                 spacing: ScreenTools.defaultFontPixelWidth * 0.6
                                 QGCLabel { text: qsTr("URL:") }
-                                QGCTextField {
+                                FactTextField {
                                     id: videoUriField
-                                    text: _videoUrl.rawValue.toString()
+                                    fact: _videoSettings.rtspUrl
                                     Layout.preferredWidth: ScreenTools.defaultFontPixelWidth * 28
                                 }
                             }

--- a/src/FirstRunPromptDialogs/SecureConnectionFirstRunPrompt.qml
+++ b/src/FirstRunPromptDialogs/SecureConnectionFirstRunPrompt.qml
@@ -33,6 +33,7 @@ FirstRunPrompt {
     readonly property var _customSettings:   QGroundControl.corePlugin.settings
     readonly property var _appSettings:      QGroundControl.settingsManager.appSettings
     readonly property var _videoSettings:    QGroundControl.settingsManager.videoSettings
+    readonly property var _autoConnectSettings: QGroundControl.settingsManager.autoConnectSettings
 
     property Fact _udpEnabled:       _customSettings.networkUdpListenerEnabled
     property Fact _tcpEnabled:       _customSettings.networkTcpServerEnabled
@@ -46,6 +47,7 @@ FirstRunPrompt {
     property Fact _allowlistIds:     _customSettings.securityAllowlistVehicleIds
     property Fact _wizardCompleted:  _customSettings.securityWizardCompleted
     property Fact _rememberChoice:   _customSettings.securityRememberChoice
+    property Fact _udpListenPort:    _autoConnectSettings.udpListenPort
     property Fact _mavlink2SigningKey: _appSettings.mavlink2SigningKey
     property string _pendingSigningKey: _mavlink2SigningKey && _mavlink2SigningKey.rawValue ? _mavlink2SigningKey.rawValue.toString() : ""
     property bool _showSigningKey:   false
@@ -139,6 +141,7 @@ FirstRunPrompt {
 
         _udpPort.rawValue = udpPortValue > 0 ? udpPortValue : _udpPort.rawValue
         _tcpPort.rawValue = tcpPortValue > 0 ? tcpPortValue : _tcpPort.rawValue
+        _udpListenPort.rawValue = udpPortValue > 0 ? udpPortValue : _udpListenPort.rawValue
         _udpBind.rawValue = _bindForComboIndex(udpBindCombo.currentIndex)
         _tcpBind.rawValue = _bindForComboIndex(tcpBindCombo.currentIndex)
         _videoUrl.rawValue = videoUriValue.length ? videoUriValue : _videoUrl.rawValue
@@ -148,7 +151,7 @@ FirstRunPrompt {
         _strictValidation.rawValue = strictValidationCheckbox.checked
         // _allowlistIds.rawValue = allowlistIdsCheckbox.checked
         _rememberChoice.rawValue = rememberChoiceCheckbox.checked
-        _wizardCompleted.rawValue = true
+        _wizardCompleted.rawValue = rememberChoiceCheckbox.checked
         secureSetupSettings.securityRememberChoice = rememberChoiceCheckbox.checked
         secureSetupSettings.securityWizardCompleted = rememberChoiceCheckbox.checked
 
@@ -171,9 +174,15 @@ FirstRunPrompt {
             _videoSettings.videoSource.rawValue = _videoSettings.disabledVideoSource
         }
 
+        // Recreate network links so changed secure setup and ports apply immediately.
+        QGroundControl.linkManager.disconnectNetworkLinks()
+
+        if (_udpEnabled.rawValue || _tcpEnabled.rawValue) {
+            QGroundControl.linkManager.refreshNetworkLinks()
+        }
+
         if (!_udpEnabled.rawValue && !_tcpEnabled.rawValue && !_videoEnabled.rawValue) {
             CustomQmlInterface.logSecurityEvent("Continue offline applied. Network services disabled.")
-            QGroundControl.linkManager.disconnectNetworkLinks()
         }
 
         close()
@@ -184,6 +193,11 @@ FirstRunPrompt {
             udpCheckbox.checked = false
             tcpCheckbox.checked = false
             videoCheckbox.checked = false
+            _udpEnabled.rawValue = false
+            _tcpEnabled.rawValue = false
+            _videoEnabled.rawValue = false
+            _wizardCompleted.rawValue = false
+            QGroundControl.linkManager.disconnectNetworkLinks()
         }
     }
 

--- a/src/FirstRunPromptDialogs/SecureConnectionFirstRunPrompt.qml
+++ b/src/FirstRunPromptDialogs/SecureConnectionFirstRunPrompt.qml
@@ -142,6 +142,9 @@ FirstRunPrompt {
         _udpBind.rawValue = _bindForComboIndex(udpBindCombo.currentIndex)
         _tcpBind.rawValue = _bindForComboIndex(tcpBindCombo.currentIndex)
         _videoUrl.rawValue = videoUriValue.length ? videoUriValue : _videoUrl.rawValue
+        if (videoUriValue.length) {
+            _videoSettings.rtspUrl.rawValue = videoUriValue
+        }
         _strictValidation.rawValue = strictValidationCheckbox.checked
         // _allowlistIds.rawValue = allowlistIdsCheckbox.checked
         _rememberChoice.rawValue = rememberChoiceCheckbox.checked
@@ -190,7 +193,7 @@ FirstRunPrompt {
         anchors.left: parent.left
         anchors.leftMargin: ScreenTools.defaultFontPixelWidth
         width:      ScreenTools.defaultFontPixelWidth * 56
-        spacing:    ScreenTools.defaultFontPixelHeight * 0.4
+        spacing:    ScreenTools.defaultFontPixelHeight * 0.3
 
         QGCFlickable {
             Layout.fillWidth:       true
@@ -202,7 +205,7 @@ FirstRunPrompt {
             ColumnLayout {
                 id:         formColumn
                 width:      parent.width
-                spacing:    ScreenTools.defaultFontPixelHeight * 0.5
+                spacing:    ScreenTools.defaultFontPixelHeight * 0.4
 
                 QGCLabel {
                     text:               qsTr("Configure Connections (Secure by Default)")
@@ -322,9 +325,9 @@ FirstRunPrompt {
                                 Layout.fillWidth: true
                                 spacing: ScreenTools.defaultFontPixelWidth * 0.6
                                 QGCLabel { text: qsTr("URL:") }
-                                FactTextField {
+                                QGCTextField  {
                                     id: videoUriField
-                                    fact: _videoSettings.rtspUrl
+                                    text: _videoUrl.rawValue.toString()
                                     Layout.preferredWidth: ScreenTools.defaultFontPixelWidth * 28
                                 }
                             }
@@ -364,19 +367,19 @@ FirstRunPrompt {
                                 anchors.fill: parent
                                 anchors.margins: ScreenTools.defaultFontPixelWidth * 0.6
                                 spacing: ScreenTools.defaultFontPixelHeight * 0.2
-
-                                QGCLabel {
-                                    text: qsTr("Signing key (hex or passphrase)")
-                                    Layout.fillWidth: true
-                                }
+                           
                                 RowLayout {
                                     Layout.fillWidth: true
                                     spacing: ScreenTools.defaultFontPixelWidth * 0.5
 
+                                    QGCLabel {
+                                    text: qsTr("Signing key:")
+                                    }
+
                                     QGCTextField {
                                         id: signingKeyField
                                         // Layout.fillWidth: true
-                                        width: ScreenTools.defaultFontPixelWidth * 100
+                                        Layout.preferredWidth: ScreenTools.defaultFontPixelWidth * 22.5
                                         text: _pendingSigningKey
                                         echoMode: _showSigningKey ? TextInput.Normal : TextInput.Password
                                         placeholderText: qsTr("Enter key or leave blank to keep current key")

--- a/src/FlightDisplay/FlightDisplayViewVideo.qml
+++ b/src/FlightDisplay/FlightDisplayViewVideo.qml
@@ -236,6 +236,17 @@ Item {
             }
         }
 
+        // Keep an explicit fullscreen double-click catcher here since camera extraControls
+        // are hidden while in fullscreen mode.
+        MouseArea {
+            anchors.fill: parent
+            enabled: QGroundControl.videoManager.fullScreen
+            acceptedButtons: Qt.LeftButton
+            onDoubleClicked: {
+                QGroundControl.videoManager.fullScreen = false
+            }
+        }
+
         //-- Camera Extra Controls QML
         Loader {
             anchors.fill: parent

--- a/src/QmlControls/TouchSelectArea.qml
+++ b/src/QmlControls/TouchSelectArea.qml
@@ -132,20 +132,23 @@ Item {
     MouseArea {
         id: mouseArea
         anchors.fill: parent
-        enabled: !selectItem.busy       
+        enabled: true
         pressAndHoldInterval: enableRectangle ? 200 : 800
         property bool isPressAndHold: false
         onClicked: {
+            if (selectItem.busy) return
             if(!enablePoint) return
             touchPointTrack(mouseX, mouseY)
         }
         onPressed: {
+            if (selectItem.busy) return
             if(!enableRectangle) return
             isPressAndHold = false
             rangeRect.x = mouseX
             rangeRect.y = mouseY
         }
         onPressAndHold: {
+            if (selectItem.busy) return
             if(!enableRectangle) {
                 touchPressAndHold(mouseX / selectItem.width, mouseY / selectItem.height)
                 return
@@ -155,6 +158,7 @@ Item {
             rangeRect.opacity = 1
         }
         onPositionChanged: {
+            if (selectItem.busy) return
             if(!enableRectangle || !isPressAndHold) return
             if(rangeRect.opacity == 1 && !hightlightGroup.running && !animationGroup.running) {
                 rangeRect.width = Math.abs(mouseX - rangeRect.x)
@@ -162,6 +166,7 @@ Item {
             }
         }
         onReleased: {
+            if (selectItem.busy) return
             if(!enableRectangle || !isPressAndHold) return
             if(rangeRect.opacity == 1 && !hightlightGroup.running && !animationGroup.running) {
                 rangeRectTrack()

--- a/src/VideoManager/VideoManager.cc
+++ b/src/VideoManager/VideoManager.cc
@@ -799,13 +799,24 @@ VideoManager::_updateSettings(unsigned id)
 
     if(_activeVehicle && _activeVehicle->cameraManager()) {
         QGCVideoStreamInfo* pInfo = _activeVehicle->cameraManager()->currentStreamInstance();
+        if (!pInfo && id == 0) {
+            qCWarning(VideoManagerLog) << "Auto-discovery: currentStreamInstance is null for primary stream";
+        }
         if(pInfo) {
             if (id == 0) {
+                qCWarning(VideoManagerLog).noquote()
+                    << QStringLiteral("Auto-discovery primary stream: type=%1 uri=\"%2\"")
+                          .arg(pInfo->type())
+                          .arg(pInfo->uri());
                 qCDebug(VideoManagerLog) << "Configure primary stream:" << pInfo->uri();
                 switch(pInfo->type()) {
                     case VIDEO_STREAM_TYPE_RTSP:
                         if ((settingsChanged |= _updateVideoUri(id, pInfo->uri()))) {
                             _toolbox->settingsManager()->videoSettings()->videoSource()->setRawValue(VideoSettings::videoSourceRTSP);
+                        }
+                        if (!pInfo->uri().isEmpty() &&
+                            _toolbox->settingsManager()->videoSettings()->rtspUrl()->rawValue().toString() != pInfo->uri()) {
+                            _toolbox->settingsManager()->videoSettings()->rtspUrl()->setRawValue(pInfo->uri());
                         }
                         break;
                     case VIDEO_STREAM_TYPE_TCP_MPEG:
@@ -835,6 +846,10 @@ VideoManager::_updateSettings(unsigned id)
             else if (id == 1) { //-- Thermal stream (if any)
                 QGCVideoStreamInfo* pTinfo = _activeVehicle->cameraManager()->thermalStreamInstance();
                 if (pTinfo) {
+                    qCWarning(VideoManagerLog).noquote()
+                        << QStringLiteral("Auto-discovery thermal stream: type=%1 uri=\"%2\"")
+                              .arg(pTinfo->type())
+                              .arg(pTinfo->uri());
                     qCDebug(VideoManagerLog) << "Configure secondary stream:" << pTinfo->uri();
                     switch(pTinfo->type()) {
                         case VIDEO_STREAM_TYPE_RTSP:
@@ -851,6 +866,9 @@ VideoManager::_updateSettings(unsigned id)
                             settingsChanged |= _updateVideoUri(id, pTinfo->uri());
                             break;
                     }
+                }
+                else {
+                    qCWarning(VideoManagerLog) << "Auto-discovery: thermalStreamInstance is null";
                 }
             }
             return settingsChanged;
@@ -1025,7 +1043,14 @@ VideoManager::_startReceiver(unsigned id)
                 _deferPrimaryStartUntilSinkReady = false;
             }
             _videoReceiver[id]->start(_videoUri[id], timeout, _lowLatencyStreaming[id] ? -1 : 0);
+        } else {
+            qCWarning(VideoManagerLog)
+                << "StartReceiver skipped due to empty URI. id=" << id
+                << "videoSource=" << source;
         }
+    } else {
+        qCWarning(VideoManagerLog)
+            << "StartReceiver skipped: receiver is null for id" << id;
     }
 #else
     Q_UNUSED(id);

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -298,7 +298,7 @@ Rectangle {
                             GridLayout {
                                 id:         videoGrid
                                 columns:    2
-                                visible:    _videoSettings.visible
+                                visible:    false
 
                                 QGCLabel {
                                     text:               qsTr("Video Settings")

--- a/src/ui/preferences/VideoSettingsPage.qml
+++ b/src/ui/preferences/VideoSettingsPage.qml
@@ -1,0 +1,194 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick                  2.3
+import QtQuick.Controls         1.2
+import QtQuick.Layouts          1.2
+
+import QGroundControl               1.0
+import QGroundControl.FactSystem    1.0
+import QGroundControl.FactControls  1.0
+import QGroundControl.Controls      1.0
+import QGroundControl.ScreenTools   1.0
+import QGroundControl.Palette       1.0
+
+Rectangle {
+    id:                 _root
+    color:              qgcPal.window
+    anchors.fill:       parent
+    anchors.margins:    ScreenTools.defaultFontPixelWidth
+
+    property real   _margins:               ScreenTools.defaultFontPixelWidth
+    property real   _comboFieldWidth:       ScreenTools.defaultFontPixelWidth * 30
+    property var    _videoSettings:         QGroundControl.settingsManager.videoSettings
+    property string _videoSource:           _videoSettings.videoSource.rawValue
+    property bool   _isGst:                 QGroundControl.videoManager.isGStreamer
+    property bool   _isUDP264:              _isGst && _videoSource === _videoSettings.udp264VideoSource
+    property bool   _isUDP265:              _isGst && _videoSource === _videoSettings.udp265VideoSource
+    property bool   _isRTSP:                _isGst && _videoSource === _videoSettings.rtspVideoSource
+    property bool   _isTCP:                 _isGst && _videoSource === _videoSettings.tcpVideoSource
+    property bool   _isMPEGTS:              _isGst && _videoSource === _videoSettings.mpegtsVideoSource
+    property bool   _showSaveVideoSettings: _isGst || QGroundControl.videoManager.autoStreamConfigured
+
+    QGCPalette { id: qgcPal }
+
+    QGCFlickable {
+        anchors.fill:       parent
+        clip:               true
+        contentHeight:      settingsColumn.height
+        contentWidth:       settingsColumn.width
+
+        ColumnLayout {
+            id:                         settingsColumn
+            anchors.horizontalCenter:   parent.horizontalCenter
+
+            Rectangle {
+                Layout.preferredHeight: videoGrid.height + (_margins * 2)
+                Layout.preferredWidth:  videoGrid.width + (_margins * 2)
+                Layout.fillWidth:       true
+                color:                  qgcPal.windowShade
+                visible:                _videoSettings.visible
+
+                GridLayout {
+                    id:                         videoGrid
+                    anchors.top:                parent.top
+                    anchors.horizontalCenter:   parent.horizontalCenter
+                    anchors.margins:            _margins
+                    columns:                    2
+                    visible:                    _videoSettings.visible
+
+                    QGCLabel {
+                        text:               qsTr("Video Settings")
+                        Layout.columnSpan:  2
+                        Layout.alignment:   Qt.AlignHCenter
+                    }
+
+                    QGCLabel {
+                        text:       qsTr("Source")
+                        visible:    _videoSettings.videoSource.visible
+                    }
+                    FactComboBox {
+                        Layout.preferredWidth:  _comboFieldWidth
+                        indexModel:             false
+                        fact:                   _videoSettings.videoSource
+                        visible:                _videoSettings.videoSource.visible
+                    }
+
+                    QGCLabel {
+                        text:       qsTr("UDP Port")
+                        visible:    (_isUDP264 || _isUDP265 || _isMPEGTS) && _videoSettings.udpPort.visible
+                    }
+                    FactTextField {
+                        Layout.preferredWidth:  _comboFieldWidth
+                        fact:                   _videoSettings.udpPort
+                        visible:                (_isUDP264 || _isUDP265 || _isMPEGTS) && _videoSettings.udpPort.visible
+                    }
+
+                    QGCLabel {
+                        text:       qsTr("RTSP URL")
+                        visible:    _isRTSP && _videoSettings.rtspUrl.visible
+                    }
+                    FactTextField {
+                        Layout.preferredWidth:  _comboFieldWidth
+                        fact:                   _videoSettings.rtspUrl
+                        visible:                _isRTSP && _videoSettings.rtspUrl.visible
+                    }
+
+                    QGCLabel {
+                        text:       qsTr("TCP URL")
+                        visible:    _isTCP && _videoSettings.tcpUrl.visible
+                    }
+                    FactTextField {
+                        Layout.preferredWidth:  _comboFieldWidth
+                        fact:                   _videoSettings.tcpUrl
+                        visible:                _isTCP && _videoSettings.tcpUrl.visible
+                    }
+
+                    QGCLabel {
+                        text:       qsTr("Aspect Ratio")
+                        visible:    _isGst && _videoSettings.aspectRatio.visible
+                    }
+                    FactTextField {
+                        Layout.preferredWidth:  _comboFieldWidth
+                        fact:                   _videoSettings.aspectRatio
+                        visible:                _isGst && _videoSettings.aspectRatio.visible
+                    }
+
+                    QGCLabel {
+                        text:       qsTr("Record File Format")
+                        visible:    _showSaveVideoSettings && _videoSettings.recordingFormat.visible
+                    }
+                    FactComboBox {
+                        Layout.preferredWidth:  _comboFieldWidth
+                        fact:                   _videoSettings.recordingFormat
+                        visible:                _showSaveVideoSettings && _videoSettings.recordingFormat.visible
+                    }
+
+                    QGCLabel {
+                        text:       qsTr("Max Storage Usage")
+                        visible:    _showSaveVideoSettings && _videoSettings.maxVideoSize.visible && _videoSettings.enableStorageLimit.value
+                    }
+                    FactTextField {
+                        Layout.preferredWidth:  _comboFieldWidth
+                        fact:                   _videoSettings.maxVideoSize
+                        visible:                _showSaveVideoSettings && _videoSettings.maxVideoSize.visible && _videoSettings.enableStorageLimit.value
+                    }
+
+                    QGCLabel {
+                        text:       qsTr("Video decode priority")
+                        visible:    _videoSettings.forceVideoDecoder.visible
+                    }
+                    FactComboBox {
+                        Layout.preferredWidth:  _comboFieldWidth
+                        fact:                   _videoSettings.forceVideoDecoder
+                        visible:                _videoSettings.forceVideoDecoder.visible
+                        indexModel:             false
+                    }
+
+                    Item { width: 1; height: 1 }
+                    FactCheckBox {
+                        text:       qsTr("Disable When Disarmed")
+                        fact:       _videoSettings.disableWhenDisarmed
+                        visible:    _isGst && fact.visible
+                    }
+
+                    Item { width: 1; height: 1 }
+                    FactCheckBox {
+                        text:       qsTr("Low Latency Mode")
+                        fact:       _videoSettings.lowLatencyMode
+                        visible:    _isGst && fact.visible
+                    }
+
+                    Item { width: 1; height: 1 }
+                    FactCheckBox {
+                        text:       qsTr("Auto-Delete Saved Recordings")
+                        fact:       _videoSettings.enableStorageLimit
+                        visible:    _showSaveVideoSettings && fact.visible
+                    }
+
+                    Item { width: 1; height: 1 }
+                    FactCheckBox {
+                        text:       qsTr("Disable FPV Streaming")
+                        fact:       _videoSettings.disableFPVVideo
+                    }
+
+                    QGCLabel {
+                        text:       qsTr("FPV URL")
+                        visible:    _videoSettings.disableFPVVideo.value
+                    }
+                    FactTextField {
+                        Layout.preferredWidth:  _comboFieldWidth
+                        fact:                   _videoSettings.fpvUrl
+                        visible:                _videoSettings.disableFPVVideo.value
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
bug [#8018](https://argosdyne.mytuleap.com/plugins/tracker/?aid=8018)
bug #[7985](https://argosdyne.mytuleap.com/plugins/tracker/?aid=7985)
[ALES QGC] 소니카메라 화면에서 더블 터치시 전체화면으로 변경후 더블 터치시 기본화면으로 돌아오지 않음.
[QGC][Cyber Security] Secure Setup can still play streaming video even if you enter an incorrect URL

add video tap in application setting for user to edit video url.
Edit Secure setup screen layout for better user experience.