### PR TITLE
Fix bug Thermal Zoom still enable when thermal is not displayed

### DIFF
--- a/src/Camera/CodevCameraVisual.qml
+++ b/src/Camera/CodevCameraVisual.qml
@@ -33,6 +33,9 @@ Item {
     property bool spotMeteringEnable: false
     property bool spotFocusEnable: false
     property bool aiInThermal: !(!_aiSource || _aiSource.enumIndex === 0)
+    property bool _thermalVisible: QGroundControl.videoManager.hasThermal &&
+                                   _camera  &&
+                                   _camera.thermalMode !== QGCCameraControl.THERMAL_OFF
     property var aiParentItem: aiInThermal ? thermalOverlayItem : videoContentOverlayItem
 
     property string _cameraModelUpper: _camera ? ((_camera.modelName || "").toUpperCase()) : ""
@@ -62,7 +65,7 @@ Item {
         target: AVIATORInterface
 
         function thermalZoomTigger(start) {
-            if(start && _irZoom) {
+            if(start && _irZoom && _thermalVisible) {
                 var v = _irZoom.value + _irZoom.increment
                 if(v > (_irZoom.max + 0.01)) {
                     v = _irZoom.min


### PR DESCRIPTION
bug [#8022](https://argosdyne.mytuleap.com/plugins/tracker/?aid=8022) [ALES QGC] 소니 카메라 장착 상태에서 조종기 Fn2 키를 누르면 Zoom in OSD 화면 출력됨.
