### PR TITLE
Fix crash when loading mission file

### DIFF
--- a/src/MissionManager/TransectStyleComplexItem.cc
+++ b/src/MissionManager/TransectStyleComplexItem.cc
@@ -128,13 +128,12 @@ TransectStyleComplexItem::TransectStyleComplexItem(PlanMasterController* masterC
 
     // Save previous vehicle speed
     MultiVehicleManager* manager = qgcApp()->toolbox()->multiVehicleManager();
-    if(manager) {
-        if(manager->activeVehicle()->firmwareType() == MAV_AUTOPILOT_ARDUPILOTMEGA) {
-            qInfo() << "This is APM";
+    Vehicle* activeVehicle = manager ? manager->activeVehicle() : nullptr;
 
-            _previousVehicleSpeed = manager->activeVehicle()->parameterManager()->getParameter(MAV_COMP_ID_AUTOPILOT1, "WPNAV_SPEED")->rawValue().toDouble();
-
-            qInfo() << "_previousVehicleSpeed = " << _previousVehicleSpeed;
+    if (activeVehicle && activeVehicle->firmwareType() == MAV_AUTOPILOT_ARDUPILOTMEGA) {
+        Fact* wpNavSpeed = activeVehicle->parameterManager()->getParameter(MAV_COMP_ID_AUTOPILOT1, "WPNAV_SPEED");
+        if (wpNavSpeed) {
+            _previousVehicleSpeed = wpNavSpeed->rawValue().toDouble();
         }
     }
 }


### PR DESCRIPTION
Root cause: Loading a Survey .plan constructs TransectStyleComplexItem, which dereferenced manager->activeVehicle() without checking for null when no vehicle was connected.
Solution: Add null checks for activeVehicle and WPNAV_SPEED before reading the previous vehicle speed.