### PR TITLE
Improve JPattern speed and U-turn continuity

### DIFF
--- a/src/MissionManager/TransectStyleComplexItem.cc
+++ b/src/MissionManager/TransectStyleComplexItem.cc
@@ -1216,19 +1216,17 @@ int TransectStyleComplexItem::lastSequenceNumber(void) const
                 }
                 break;
             case CoordTypeYellowScanMaxSpeed:
-                itemCount++; // Speed change command
-                break;
-            case CoordTypeYellowScanTurnSpeed:
-                itemCount++; // Turn speed change command
+                itemCount++; // Max speed command
                 break;
             case CoordTypeYellowScan:
-                itemCount++; // Waypoint only
+            case CoordTypeYellowScanTurn:
+                itemCount++; // Waypoint
                 break;
             case CoordTypeYellowScanChangeYaw:
                 itemCount++; // Yaw command
                 break;
             case CoordTypeYellowScanPreviousSpeed:
-                itemCount++; // Speed restore command
+                itemCount++; // Restore previous speed command
                 break;
             case CoordTypeSurveyExit:
                 bool lastSurveyExit = coordIndex == _rgFlightPathCoordInfo.count() - 1;
@@ -1343,27 +1341,7 @@ void TransectStyleComplexItem::_appendYSInitPathMaxSpeed(QList<MissionItem*>& it
                                         MAV_CMD_DO_CHANGE_SPEED,
                                         MAV_FRAME_MISSION,
                                         _masterController->controllerVehicle()->multiRotor() ? 1 /* groundspeed */ : 0 /* airspeed */,    // Change airspeed or groundspeed
-                                        20,
-                                        -1,                                                                 // No throttle change
-                                        0,                                                                  // Absolute speed change
-                                        0, 0, 0,                                                            // param 5-7 not used
-                                        true,                                                               // autoContinue
-                                        false,                                                              // isCurrentItem
-                                        missionItemParent);
-    items.append(item);
-}
-
-void TransectStyleComplexItem::_appendYSInitPathTurnSpeed(QList<MissionItem*>& items, QObject* missionItemParent, int& seqNum)
-{
-    // Slow down to a fixed 3 m/s before entering the U-turn so the vehicle can
-    // stay tighter to the generated semicircle waypoints.
-    constexpr double turnSpeed = 5.0;
-
-    MissionItem* item = new MissionItem(seqNum++,
-                                        MAV_CMD_DO_CHANGE_SPEED,
-                                        MAV_FRAME_MISSION,
-                                        _masterController->controllerVehicle()->multiRotor() ? 1 /* groundspeed */ : 0 /* airspeed */,    // Change airspeed or groundspeed
-                                        turnSpeed,
+                                        10,
                                         -1,                                                                 // No throttle change
                                         0,                                                                  // Absolute speed change
                                         0, 0, 0,                                                            // param 5-7 not used
@@ -1376,11 +1354,17 @@ void TransectStyleComplexItem::_appendYSInitPathTurnSpeed(QList<MissionItem*>& i
 void TransectStyleComplexItem::_appendYSInitPathPreviousSpeed(QList<MissionItem*>& items, QObject* missionItemParent, int& seqNum)
 {
     // IMPORTANT NOTE: If anything changes here you must also change SpeedSection::scanForSettings
+    // ArduPilot WPNAV_SPEED is stored in cm/s. If it is unavailable (PX4,
+    // offline planning, or parameters not loaded), restore to a conservative
+    // fixed speed instead of relying on a possibly unrelated cruise setting.
+    const double restoreSpeed = qIsFinite(_previousVehicleSpeed) && _previousVehicleSpeed > 0.0
+            ? _previousVehicleSpeed / 100.0
+            : 5.0;
     MissionItem* item = new MissionItem(seqNum++,
                                         MAV_CMD_DO_CHANGE_SPEED,
                                         MAV_FRAME_MISSION,
                                         _masterController->controllerVehicle()->multiRotor() ? 1 /* groundspeed */ : 0 /* airspeed */,    // Change airspeed or groundspeed
-                                        _previousVehicleSpeed / 100,
+                                        restoreSpeed,
                                         -1,                                                                 // No throttle change
                                         0,                                                                  // Absolute speed change
                                         0, 0, 0,                                                            // param 5-7 not used
@@ -1388,6 +1372,22 @@ void TransectStyleComplexItem::_appendYSInitPathPreviousSpeed(QList<MissionItem*
                                         false,                                                              // isCurrentItem
                                         missionItemParent);
     items.append(item);
+}
+
+void TransectStyleComplexItem::_appendYSInitPathTurnWaypoint(QList<MissionItem*>& items, QObject* missionItemParent, int& seqNum, MAV_FRAME mavFrame, const QGeoCoordinate& coordinate)
+{
+    // Use only standard NAV_WAYPOINT commands for both PX4 and ArduPilot.
+    // Both multicopter controllers smooth a consecutive previous/current/next
+    // waypoint triplet. A zero hold time prevents an intentional stop, while
+    // the small radius keeps the generated trajectory close to the U-turn.
+    constexpr float turnAcceptanceRadius = 2.0f;
+    _appendWaypoint(items,
+                    missionItemParent,
+                    seqNum,
+                    mavFrame,
+                    0 /* holdTime */,
+                    coordinate,
+                    turnAcceptanceRadius);
 }
 
 void TransectStyleComplexItem::_appendYSInitPathYaw(QList<MissionItem*>& items, QObject* missionItemParent, int& seqNum){
@@ -1541,14 +1541,14 @@ void TransectStyleComplexItem::_buildAndAppendMissionItems(QList<MissionItem*>& 
         case CoordTypeYellowScanMaxSpeed:
             _appendYSInitPathMaxSpeed(items, missionItemParent, seqNum);
             break;
-        case CoordTypeYellowScanTurnSpeed:
-            _appendYSInitPathTurnSpeed(items, missionItemParent, seqNum);
-            break;
         case CoordTypeYellowScanPreviousSpeed:
             _appendYSInitPathPreviousSpeed(items, missionItemParent, seqNum);
             break;
         case CoordTypeYellowScan:            
             _appendWaypoint(items, missionItemParent, seqNum, mavFrame, 0 /* holdTime */, coordInfo.coord);
+            break;
+        case CoordTypeYellowScanTurn:
+            _appendYSInitPathTurnWaypoint(items, missionItemParent, seqNum, mavFrame, coordInfo.coord);
             break;
         case CoordTypeYellowScanChangeYaw:
             _appendYSInitPathYaw(items, missionItemParent, seqNum);

--- a/src/MissionManager/TransectStyleComplexItem.h
+++ b/src/MissionManager/TransectStyleComplexItem.h
@@ -164,9 +164,9 @@ protected:
     void    _appendLoadedMissionItems       (QList<MissionItem*>& items, QObject* missionItemParent);
     void    _recalcComplexDistance          (void);
     void    _appendYSInitPathMaxSpeed       (QList<MissionItem*>& items, QObject* missionItemParent, int& seqNum);
-    void    _appendYSInitPathTurnSpeed      (QList<MissionItem*>& items, QObject* missionItemParent, int& seqNum);
     void    _appendYSInitPathPreviousSpeed  (QList<MissionItem*>& items, QObject* missionItemParent, int& seqNum);
     void    _appendYSInitPathYaw            (QList<MissionItem*>& items, QObject* missionItemParent, int& seqNum);
+    void    _appendYSInitPathTurnWaypoint   (QList<MissionItem*>& items, QObject* missionItemParent, int& seqNum, MAV_FRAME mavFrame, const QGeoCoordinate& coordinate);
 
     int                 _sequenceNumber = 0;
     QGeoCoordinate      _coordinate;
@@ -181,8 +181,8 @@ protected:
         CoordTypeSurveyExit,            ///< Waypoint at exit edge of survey polygon
         CoordTypeTurnaround,            ///< Turnaround extension waypoint
         CoordTypeYellowScan,            ///< YellowScan initiation path
-        CoordTypeYellowScanMaxSpeed,    ///< YellowScan initiation path max speed (10 m/s)
-        CoordTypeYellowScanTurnSpeed,   ///< YellowScan pre-U-turn slow speed (3 m/s)
+        CoordTypeYellowScanTurn,        ///< YellowScan smooth U-turn waypoint
+        CoordTypeYellowScanMaxSpeed,    ///< YellowScan initiation path max speed(10m/s)
         CoordTypeYellowScanPreviousSpeed,
         CoordTypeYellowScanChangeYaw
     };
@@ -270,6 +270,6 @@ private:
     // Deprecated json keys
     static const char* _jsonTerrainFollowKeyDeprecated;
 
-    double _previousVehicleSpeed;    
-    double _yellowScanInitPathAngle;
+    double _previousVehicleSpeed = -1.0;
+    double _yellowScanInitPathAngle = 0.0;
 };

--- a/src/MissionManager/YellowScanInitPathComplexItem.cc
+++ b/src/MissionManager/YellowScanInitPathComplexItem.cc
@@ -316,41 +316,41 @@ void YellowScanInitPathComplexItem::_rebuildTransectsPhase1(void)
     transect.append({end,   CoordTypeYellowScan});
     transect.append({end, CoordTypeYellowScanChangeYaw});
 
-    // 2회 왕복
-    transect.append({end,   CoordTypeYellowScan});
-    transect.append({end, CoordTypeYellowScanChangeYaw});
+    // Backward. Reassert the same heading at the reversal point without adding
+    // a duplicate navigation waypoint.
     transect.append({start, CoordTypeYellowScan});
     transect.append({start, CoordTypeYellowScanChangeYaw});
 
-    // 3회 왕복
-    transect.append({start, CoordTypeYellowScan});    
-    transect.append({end,   CoordTypeYellowScan});    
-   // Reduce speed before entering the U-turn so the drone tracks the semicircle
-    // more tightly instead of overshooting the turn.
-    transect.append({end,   CoordTypeYellowScanTurnSpeed});
+    // Final forward line. There must be no CONDITION/DO command between this
+    // waypoint and the U-turn or ArduCopter cannot create a continuous path.
+    transect.append({end,   CoordTypeYellowScan});
+
     // 반원 생성
     double rightAzimuth = bearing + 90.0;
     if (rightAzimuth >= 360.0) rightAzimuth -= 360.0;
 
     QGeoCoordinate semicircleCenter = end.atDistanceAndAzimuth(radius, rightAzimuth);
 
+    // Use approximately 5 m between arc control points. Fewer, well-spaced
+    // points give PX4 and ArduPilot more room to maintain a smooth trajectory,
+    // while the bounds keep small turns usable and mission size predictable.
+    const int turnSegments = qBound(6, qCeil((PI * radius) / 5.0), 18);
+
     vector<pair<double,double>> semicircle = generate_semicircle_from_origin(
         semicircleCenter.latitude(),
         semicircleCenter.longitude(),
         radius,
-        radius,
+        turnSegments,
         rightAzimuth - 90
         );
 
-    for (const auto& p : semicircle) {
+    // Index zero is exactly the final straight-line waypoint. Skipping it is
+    // essential: two identical NAV points make the vehicle stop before turning.
+    for (size_t i = 1; i < semicircle.size(); ++i) {
+        const auto& p = semicircle[i];
         TransectStyleComplexItem::CoordInfo_t coordInfo;
         coordInfo.coord = QGeoCoordinate(p.first, p.second);
-        coordInfo.coordType = CoordTypeYellowScan;
-
-        if (!transect.isEmpty() && transect.last().coord.isValid() && transect.last().coord.distanceTo(coordInfo.coord) < 0.05) {
-            continue;
-        }
-
+        coordInfo.coordType = CoordTypeYellowScanTurn;
         transect.append(coordInfo);
     }
 


### PR DESCRIPTION
Improve JPattern speed and U-turn continuity
- remove duplicate waypoints that caused stopping before the U-turn
- use standard NAV_WAYPOINT commands for both PX4 and ArduPilot
- add a dedicated coordinate type for U-turn waypoints